### PR TITLE
lake_ops: convert pmc + openalex to ops.run (rollout complete)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -12,9 +12,9 @@ rationale for *what's next*, not how it was built.
   catalog-adjacent native state (a second `ops` attachment, not DuckLake data);
   wire every ingestor to record runs via `ops.run(...)`. Unblocks watermark-driven
   incrementals (e.g. OpenAlex `updated_date > last_pull`). *Module + bootstrap
-  done; 5/7 ingestors (icite, reporter, ctgov, scp, census_geo) + europepmc go
-  through `ops.run`. Remaining: convert `pmc`/`openalex` after their loads finish;
-  add watermarks; `dataset_contract`.*
+  done; **all 7 ingestors + europepmc** record runs via `ops.run`. Remaining: add
+  watermark cursors (OpenAlex `updated_date` first); `dataset_contract` (with the
+  versioned-views work).*
 - **Scoped roles** — replace the admin bootstrap credential with `lake_writer`
   (ingest) and `lake_reader` (consumers) Postgres roles + scoped R2 tokens.
 - **Versioned consumer views + `dataset_contract` registry** — per-source stable

--- a/docs/design/lake_ops.md
+++ b/docs/design/lake_ops.md
@@ -191,16 +191,18 @@ with ops.run(con, source="openalex", target=target) as r:
 1. **Done.** `cdsci.lake.ops` + the bootstrap (attach `ops`, create schema/tables,
    seed `source`) wired into `lake_connect()` write mode; offline tests on the
    local sibling-file backend.
-2. **Done (5 of 7).** `icite`, `reporter`, `ctgov`, `scp`, `census_geo` and the
-   new `europepmc` source go through `ops.run(...)`; the hand-rolled before/after
-   is gone. Behaviour-preserving — `summary()` is a superset of the old dict, and
-   each ingest spreads in its source-specific keys. **`pmc` and `openalex` are
-   deferred** — they were mid-bulk-load when this landed; convert once their loads
-   finish (their `ingest()` didn't bracket snapshots before, so nothing regresses).
-   Multi-table ingestors (`ctgov`, `scp`, `census_geo`) currently record **one**
-   run per invocation with `target` = the schema namespace and the summed row
-   count, rather than one row per table — adequate for now; revisit if per-table
-   granularity is needed.
+2. **Done (all 7 + europepmc).** Every ingestor records via `ops.run(...)`; the
+   hand-rolled before/after is gone. `icite`/`reporter`/`ctgov`/`scp`/`census_geo`/
+   `europepmc` were converted first; `pmc` and `openalex` followed (their CLIs —
+   pmc's per-range `ingest()`, openalex's `entities` loop and `ingest_works` — each
+   record one run per invocation). Behaviour-preserving: `summary()` is a superset
+   of the old dict and each ingest spreads in its source-specific keys.
+   Multi-table ingestors (`ctgov`, `scp`, `census_geo`, `pmc`) record **one** run
+   per invocation with `target` = the schema namespace and the summed row count,
+   rather than one row per table — adequate for now; revisit if per-table
+   granularity is needed. (pmc/openalex were not prod-validated post-conversion —
+   their bulk loads were still running; the `ops.run` path itself is proven live
+   via icite/europepmc.)
 3. Add watermark use where it pays first: **OpenAlex** (`updated_date`) and
    whatever daily-sync source lands first (Retraction Watch — roadmap). ctgov/PMC
    can adopt cursors opportunistically; full re-read stays correct meanwhile.

--- a/src/cdsci/lake/sources/openalex/__main__.py
+++ b/src/cdsci/lake/sources/openalex/__main__.py
@@ -12,8 +12,9 @@ from __future__ import annotations
 
 import typer
 
+from ... import ops
 from ...config import get_settings
-from ...connect import lake_connect
+from ...connect import LAKE, lake_connect
 from .ingest import ENTITIES, ingest_entity, ingest_works, part_urls
 
 app = typer.Typer(
@@ -56,12 +57,16 @@ def entities(
     s = get_settings()
     con = lake_connect(s)
     try:
-        for name in entity or list(ENTITIES):
-            n = ingest_entity(
-                name, schema=schema, version=version, mode=mode,
-                max_files=max_files, settings=s, con=con,
-            )
-            typer.echo(f"{name}: {n:,}")
+        with ops.run(con, source="openalex", target=f"{LAKE}.{schema}", version=version) as r:
+            total = 0
+            for name in entity or list(ENTITIES):
+                n = ingest_entity(
+                    name, schema=schema, version=version, mode=mode,
+                    max_files=max_files, settings=s, con=con,
+                )
+                total += n
+                typer.echo(f"{name}: {n:,}")
+            r.rows = total
     finally:
         con.close()
 

--- a/src/cdsci/lake/sources/openalex/ingest.py
+++ b/src/cdsci/lake/sources/openalex/ingest.py
@@ -31,6 +31,7 @@ from datetime import date
 
 import duckdb
 
+from ... import ops
 from ...config import Settings, get_settings
 from ...connect import LAKE, lake_connect, upsert
 
@@ -424,21 +425,23 @@ def ingest_works(
     owns = con is None
     con = con or lake_connect(s)
     try:
-        urls = part_urls(con, "works", base=s.openalex_s3_base, max_files=max_files)
-        batches = _chunks(urls, batch)
-        totals = {"works": 0, "references": 0, "authorships": 0}
-        for n, chunk in enumerate(batches, 1):
-            totals = curate_works_batch(
-                con, chunk, schema=schema, version=version, mode=mode,
-                domains=s.openalex_domains, max_obj=s.openalex_max_object_bytes,
-            )
-            print(f"  works batch {n}/{len(batches)} ({len(chunk)} parts): "
-                  f"works={totals['works']:,} refs={totals['references']:,} "
-                  f"authorships={totals['authorships']:,}")
+        with ops.run(con, source="openalex", target=f"{LAKE}.{schema}.works", version=version) as r:
+            urls = part_urls(con, "works", base=s.openalex_s3_base, max_files=max_files)
+            batches = _chunks(urls, batch)
+            totals = {"works": 0, "references": 0, "authorships": 0}
+            for n, chunk in enumerate(batches, 1):
+                totals = curate_works_batch(
+                    con, chunk, schema=schema, version=version, mode=mode,
+                    domains=s.openalex_domains, max_obj=s.openalex_max_object_bytes,
+                )
+                print(f"  works batch {n}/{len(batches)} ({len(chunk)} parts): "
+                      f"works={totals['works']:,} refs={totals['references']:,} "
+                      f"authorships={totals['authorships']:,}")
+            r.rows = totals["works"]
     finally:
         if owns:
             con.close()
-    return {"schema": schema, "parts": len(urls), **totals}
+    return {**r.summary(), "schema": schema, "parts": len(urls), **totals}
 
 
 def ingest_entity(

--- a/src/cdsci/lake/sources/pmc/ingest.py
+++ b/src/cdsci/lake/sources/pmc/ingest.py
@@ -32,6 +32,7 @@ from pathlib import Path
 import duckdb
 import httpx
 
+from ... import ops
 from ...config import Settings, get_settings
 from ...connect import LAKE, csv_source, lake_connect, raw_dir, upsert
 from ...download import download
@@ -246,32 +247,31 @@ def ingest(
         "passages": 0,
     }
     try:
-        if file:
-            raw = Path(file) if str(file).endswith(".parquet") else materialize_raw(con, file)
-            counts = curate(con, raw, schema=schema, snapshot=snapshot, limit=limit, mode=mode)
-            summary["documents"] += counts["documents"]
-            summary["passages"] += counts["passages"]
-            summary["ranges"].append(Path(file).name)
-            return summary
-
-        for filename in ranges if ranges is not None else list_ranges(s):
-            tar = download_range(filename, s)
-            ndjson = raw_dir("pmc", s) / (filename.replace(".tar.gz", ".ndjson.gz"))
-            n_files = tar_to_ndjson(tar, ndjson)
-            raw = materialize_raw(con, ndjson)
-            counts = curate(con, raw, schema=schema, snapshot=snapshot, limit=limit, mode=mode)
-            summary["documents"] += counts["documents"]
-            summary["passages"] += counts["passages"]
-            summary["ranges"].append(
-                {"file": filename, "articles": n_files, **counts}
-            )
-            if not keep_raw:
-                # The silver tables on R2 are the faithful copy, so the local
-                # tarball / NDJSON / bronze Parquet are all transient — delete
-                # them per range so disk stays ~one range, not 22 × 7 GB.
-                tar.unlink(missing_ok=True)
-                ndjson.unlink(missing_ok=True)
-                raw.unlink(missing_ok=True)
-        return summary
+        with ops.run(con, source="pmc", target=f"{LAKE}.{schema}", version=snapshot) as r:
+            if file:
+                raw = Path(file) if str(file).endswith(".parquet") else materialize_raw(con, file)
+                counts = curate(con, raw, schema=schema, snapshot=snapshot, limit=limit, mode=mode)
+                summary["documents"] += counts["documents"]
+                summary["passages"] += counts["passages"]
+                summary["ranges"].append(Path(file).name)
+            else:
+                for filename in ranges if ranges is not None else list_ranges(s):
+                    tar = download_range(filename, s)
+                    ndjson = raw_dir("pmc", s) / (filename.replace(".tar.gz", ".ndjson.gz"))
+                    n_files = tar_to_ndjson(tar, ndjson)
+                    raw = materialize_raw(con, ndjson)
+                    counts = curate(con, raw, schema=schema, snapshot=snapshot, limit=limit, mode=mode)
+                    summary["documents"] += counts["documents"]
+                    summary["passages"] += counts["passages"]
+                    summary["ranges"].append({"file": filename, "articles": n_files, **counts})
+                    if not keep_raw:
+                        # The silver tables on R2 are the faithful copy, so the local
+                        # tarball / NDJSON / bronze Parquet are all transient — delete
+                        # them per range so disk stays ~one range, not 22 × 7 GB.
+                        tar.unlink(missing_ok=True)
+                        ndjson.unlink(missing_ok=True)
+                        raw.unlink(missing_ok=True)
+            r.rows = summary["documents"] + summary["passages"]
     finally:
         con.close()
+    return {**r.summary(), **summary}


### PR DESCRIPTION
Finishes the `lake_ops` rollout (ADR-0006) — the last two ingestors now record runs in the operational ledger, so **all 7 sources + europepmc** go through `ops.run(...)`.

- **pmc**: per-range `ingest()` loop wrapped in `ops.run` (one run per invocation; `target` = schema namespace, `rows` = documents+passages).
- **openalex**: `ingest_works` (owns its connection) and the `entities` CLI loop wrapped in `ops.run` — the two real CLI entry points each record one run.
- `summary()` stays a superset, so CLI output is unchanged.

Docs: lake_ops design rollout + ROADMAP updated to 7/7.

**Not prod-validated** — the pmc/openalex bulk loads were still running, so a validation load would conflict. The `ops.run` path itself is already proven live (icite smoke + the full europepmc load). Editing the source is safe for the in-flight processes (code is already loaded in memory).

23 offline tests pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)