### PR TITLE
Add Retraction Watch source + prod load

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -48,7 +48,7 @@ All four below join cleanly off the OpenAlex hub we now have.
 | source | cadence | distribution | join key | license | size | ingest plan |
 |--------|---------|--------------|----------|---------|------|-------------|
 | **Reliance on Science** (patents↔papers) | versioned, ~annual (Jun–Jul); latest 2024 ed. (Zenodo rec 11461587) | Zenodo concept DOI `10.5281/zenodo.3236339`, `_pcs_oa.csv` (CSV) | **OpenAlex Work ID** (+DOI/PMID crosswalks) | **CC BY-NC 4.0** — non-commercial; flag for review | ~2.5 GB core / ~25 GB full; ~16M cites | poll concept DOI ~quarterly; infrequent recurring loader |
-| **Retraction Watch** (integrity) | **weekday-daily** | Crossref GitLab `crossref/retraction-watch-data`, single `retraction_watch.csv` (semicolon multi-value) | DOI (`OriginalPaperDOI`); PMID secondary — **needs DOI→OA crosswalk** | effectively CC0 | ~65 MB, ~70.6k rows | **recurring daily sync** (weekday); full-file diff on `Record ID`; split multi-value fields |
+| **Retraction Watch** (integrity) ✅ **LANDED** | **weekday-daily** | Crossref GitLab `crossref/retraction-watch-data`, single `retraction_watch.csv` (semicolon multi-value) | DOI (`OriginalPaperDOI`); PMID secondary — **needs DOI→OA crosswalk** | effectively CC0 | ~65 MB, ~70.6k rows | **DONE** → `lake.retractionwatch.retractions` (key `record_id`, multi-value→arrays, `ops.run`); see `docs/design/retractionwatch.md`. Daily scheduler still TODO |
 | **SciSciNet v2** (sci-of-science: disruption, etc.) | **static per version**; v2 ~spring 2025, no v3 | GCS `gs://sciscinet-neo/v2/` (Parquet); HF small tables; BigQuery (form-gated) | **OpenAlex Work ID** (v2 PaperID) | BSD-3-Clause-Clear (verify) | ~210 GB core (+1.7 TB embeddings, optional) | one-time pinned-snapshot loader; use OA directly for freshness, SciSciNet only for derived measures |
 | **PreprintToPaper** (bioRxiv/medRxiv→published) | **static**, occasional versions; v2.0.0 (2025-12-19) | Zenodo `10.5281/zenodo.17992421`, `PreprintToPaper.csv` (CSV) | DOI pairs — **no OA ids/PMIDs**, needs DOI→OA crosswalk | CC-BY-4.0 | ~617 MB, ~145.5k rows | one-shot static reference table |
 
@@ -57,6 +57,7 @@ Notes:
   the shared lake. The other three are CC0 / CC-BY / BSD.
 - **Retraction Watch is the one true recurring sync** here — small and daily; a good
   first customer for whatever scheduler we adopt (cron / pg_cron + LISTEN/NOTIFY).
+  *(Source landed; the daily-schedule automation is the remaining piece.)*
 - Reliance on Science + SciSciNet v2 join on the OpenAlex Work ID **for free**;
   Retraction Watch + PreprintToPaper are DOI-only and motivate `ref.id_crosswalk`.
 - Use-case fit: **Reliance on Science** (papers→patents = translational benchmarking)

--- a/docs/design/retractionwatch.md
+++ b/docs/design/retractionwatch.md
@@ -1,0 +1,78 @@
+# Retraction Watch (`retractionwatch`) source
+
+[Retraction Watch](https://retractionwatch.com/) is the reference catalogue of
+retractions, corrections, and expressions of concern. Crossref publishes it as a
+**single rolling CSV under CC0** at
+[`gitlab.com/crossref/retraction-watch-data`](https://gitlab.com/crossref/retraction-watch-data),
+refreshed most weekdays. The `retractionwatch` source loads it into one tidy lake
+table, `lake.retractionwatch.retractions`.
+
+## Source = one rolling CC0 CSV (the recurring-sync exemplar)
+
+~70k rows, ~65 MB, 20 columns, keyed by `Record ID`. Several fields are
+**semicolon-separated** multi-value lists (with a trailing `;`): `Subject`,
+`Institution`, `Country`, `Author`, `URLS`, `Reason`. Dates are `M/D/YYYY H:MM`;
+`RetractionNature` is a small enum (`Retraction` / `Correction` / `Expression of
+concern` / `Reinstatement` / `None`); `Paywalled` is `Yes`/`No`.
+
+Unlike our versioned bulk sources, this is a **single rolling file with no
+upstream version**, so (per ADR-0005's "notes on the raw stage") we **keep each
+pull's CSV as the bronze copy** and tag the snapshot by **pull date**. It is the
+natural first customer for a scheduler (roadmap): small, CC0, weekday-daily.
+
+## One tidy table → `retractionwatch.retractions`
+
+Key: `record_id` (BIGINT). Multi-value fields become `VARCHAR[]` arrays (split on
+`;`, trimmed, empties dropped); dates parse to `DATE`; DOIs are normalized
+(trimmed, resolver-prefix stripped, lowercased, sentinels → NULL) exactly like
+`openalex.works`; PMIDs cast to BIGINT with `0` → NULL.
+
+| column | type | note |
+|--------|------|------|
+| `record_id` | BIGINT | **key** (Retraction Watch Record ID) |
+| `title` | VARCHAR | |
+| `subjects` | VARCHAR[] | subject/area tags |
+| `institutions` | VARCHAR[] | author affiliations |
+| `journal`, `publisher` | VARCHAR | |
+| `countries` | VARCHAR[] | |
+| `authors` | VARCHAR[] | `Surname, F` forms |
+| `urls` | VARCHAR[] | notice URLs |
+| `article_type` | VARCHAR | |
+| `retraction_date` | DATE | |
+| `retraction_doi` | VARCHAR | DOI of the *notice* (normalized) |
+| `retraction_pmid` | BIGINT | |
+| `original_paper_date` | DATE | |
+| `original_paper_doi` | VARCHAR | **join key** to the retracted paper (normalized) |
+| `original_paper_pmid` | BIGINT | **join key** (PMID) |
+| `retraction_nature` | VARCHAR | Retraction / Correction / Expression of concern / … |
+| `reasons` | VARCHAR[] | controlled reason phrases |
+| `paywalled` | BOOLEAN | |
+| `notes` | VARCHAR | |
+| `snapshot_version` | VARCHAR | pull date; excluded from change-detection |
+
+## Loading
+
+`python -m cdsci.lake.sources.retractionwatch run` downloads the CSV (kept in the
+raw layer) and MERGE-upserts on `record_id` — the roadmap's **"full-file diff on
+Record ID"**: a daily pull rewrites only changed notices and inserts new ones, so
+each DuckLake snapshot is the day's delta (ADR-0003). `--file` loads a local CSV;
+`--version` overrides the pull-date tag; `--limit` is a smoke cap. The run is
+recorded via `ops.run` (ADR-0006).
+
+## Why it's useful
+
+An **integrity flag** for every other source: join `original_paper_doi` /
+`original_paper_pmid` to `icite` / `reporter.publink` / `openalex` / omicidx to
+mark retracted work in any cohort or benchmarking query (e.g. exclude or surface
+retractions in a center's publication set, or in trial-linked literature). It is
+DOI/PMID-keyed, which (alongside Europe PMC) motivates the planned
+`ref.id_crosswalk`.
+
+## Open items
+
+- **DOI→OpenAlex crosswalk** — joins are by DOI/PMID today; a normalized DOI
+  crosswalk (`ref.id_crosswalk`) will make OA Work-ID joins direct.
+- **Scheduler** — this is the intended first recurring sync (weekday-daily) once
+  a scheduler lands; `snapshot_version` = pull date already supports daily diffs.
+- **`Reason` vocabulary** — kept as free-ish phrases in an array; a normalized
+  reason dimension could come later if a use case needs it.

--- a/src/cdsci/lake/config.py
+++ b/src/cdsci/lake/config.py
@@ -120,6 +120,13 @@ class Settings(BaseSettings):
     # (accession, PMCID, EXTID, SOURCE). Loaded into one tidy table keyed by the
     # database (= file stem). The directory index is scraped for the file list.
     europepmc_textmined_url: str = "https://europepmc.org/pub/databases/pmc/TextMinedTerms/"
+    # Retraction Watch — the Crossref-hosted CSV (CC0), updated weekday-daily. A
+    # single rolling ~65 MB file (~70k rows); keyed Record ID, multi-value fields
+    # semicolon-separated. The rolling file has no upstream version, so we tag the
+    # snapshot by pull date and keep the downloaded CSV as the bronze copy.
+    retractionwatch_url: str = (
+        "https://gitlab.com/crossref/retraction-watch-data/-/raw/main/retraction_watch.csv"
+    )
 
     @property
     def scp_releases_api(self) -> str:

--- a/src/cdsci/lake/ops.py
+++ b/src/cdsci/lake/ops.py
@@ -77,6 +77,8 @@ SOURCES: tuple[Source, ...] = (
            "annual", "census-cartographic", "us-public-domain"),
     Source("europepmc", "europepmc", "Europe PMC text-mined annotations (PMCID↔term)",
            "monthly", "europepmc-bulk", "europepmc-terms"),
+    Source("retractionwatch", "retractionwatch", "Retraction Watch retraction/correction notices",
+           "weekday-daily", "crossref-gitlab-csv", "cc0", watermark_strategy="full"),
 )
 
 

--- a/src/cdsci/lake/sources/retractionwatch/__init__.py
+++ b/src/cdsci/lake/sources/retractionwatch/__init__.py
@@ -1,0 +1,11 @@
+"""Retraction Watch — retraction / correction / expression-of-concern notices.
+
+One tidy table ``lake.retractionwatch.retractions`` from the Crossref-hosted CC0
+CSV, keyed ``record_id`` with multi-value fields as arrays. ``original_paper_doi``
+/ ``original_paper_pmid`` join the retracted literature (icite / publink /
+openalex / omicidx). See ``docs/design/retractionwatch.md``.
+"""
+
+from .ingest import curate, download_csv, ingest
+
+__all__ = ["curate", "download_csv", "ingest"]

--- a/src/cdsci/lake/sources/retractionwatch/__main__.py
+++ b/src/cdsci/lake/sources/retractionwatch/__main__.py
@@ -1,0 +1,36 @@
+"""CLI: ``python -m cdsci.lake.sources.retractionwatch`` — load Retraction Watch."""
+
+from __future__ import annotations
+
+import typer
+
+from .ingest import ingest
+
+app = typer.Typer(
+    help="Ingest the Retraction Watch CSV into lake.retractionwatch.retractions.",
+    add_completion=False,
+)
+
+
+@app.command("run")
+def run(
+    file: str | None = typer.Option(
+        None, "--file", help="Local CSV to load instead of downloading."
+    ),
+    version: str | None = typer.Option(
+        None, "--version", help="Snapshot label (default: today's pull date)."
+    ),
+    schema: str = typer.Option("retractionwatch", "--schema", help="Target lake schema."),
+    limit: int | None = typer.Option(None, "--limit", help="Cap rows (smoke test)."),
+) -> None:
+    """Download (unless --file) and MERGE-upsert the Retraction Watch database."""
+    summary = ingest(file=file, version=version, schema=schema, limit=limit)
+    delta = "changed" if summary["changed"] else "no change (idempotent)"
+    typer.echo(
+        f"{summary['table']} <- {summary['rows']:,} rows "
+        f"(snapshot {summary['version']}) — {delta}"
+    )
+
+
+if __name__ == "__main__":
+    app()

--- a/src/cdsci/lake/sources/retractionwatch/__main__.py
+++ b/src/cdsci/lake/sources/retractionwatch/__main__.py
@@ -12,6 +12,11 @@ app = typer.Typer(
 )
 
 
+@app.callback()
+def main() -> None:
+    """Retraction Watch ingestor (keeps the ``run`` subcommand explicit)."""
+
+
 @app.command("run")
 def run(
     file: str | None = typer.Option(

--- a/src/cdsci/lake/sources/retractionwatch/ingest.py
+++ b/src/cdsci/lake/sources/retractionwatch/ingest.py
@@ -1,0 +1,147 @@
+"""Ingest the Retraction Watch database into ``lake.retractionwatch.retractions``.
+
+Retraction Watch is the reference catalogue of retractions, corrections, and
+expressions of concern. Crossref hosts it as a **single rolling CSV** (CC0),
+updated most weekdays, at
+``gitlab.com/crossref/retraction-watch-data`` — ~70k rows, ~65 MB, keyed by
+``Record ID``, with several semicolon-separated multi-value fields.
+
+One tidy table, one row per notice (key ``record_id``). The multi-value fields
+(subjects, authors, institutions, countries, reasons, urls) become
+``VARCHAR[]`` arrays; dates parse from ``M/D/YYYY`` and DOIs are normalized
+(lowercased, prefix-stripped) like ``openalex.works``. ``original_paper_doi`` /
+``original_paper_pmid`` are the join keys to the retracted literature
+(`icite` / `reporter.publink` / `openalex` / omicidx). MERGE-upsert on
+``record_id`` is exactly the roadmap's "full-file diff on Record ID": a daily pull
+updates changed notices and inserts new ones (ADR-0003). The rolling file has no
+upstream version, so we keep each pull's CSV as bronze and tag by pull date.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import duckdb
+
+from ... import ops
+from ...config import Settings, get_settings
+from ...connect import LAKE, csv_source, lake_connect, raw_dir, upsert
+from ...download import download
+
+_TABLE = "retractionwatch.retractions"  # lake table (schema.table)
+_RAW = "retractionwatch"  # raw-download subdir name
+
+
+def _sql_str(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _today_version() -> str:
+    """Default snapshot label — the pull date (the file has no upstream version)."""
+    return date.today().isoformat()
+
+
+def _arr(col: str) -> str:
+    """SQL: a ``;``-separated multi-value column → trimmed, non-empty ``VARCHAR[]``."""
+    return (
+        f'list_transform(list_filter(string_split(coalesce("{col}", \'\'), \';\'), '
+        f"x -> trim(x) <> ''), x -> trim(x))"
+    )
+
+
+def _doi(col: str) -> str:
+    """SQL: normalize a DOI — trim, strip resolver prefix, lowercase, NULL sentinels."""
+    return (
+        f"nullif(nullif(lower(regexp_replace(trim(\"{col}\"), "
+        f"'^https?://(dx\\.)?doi\\.org/', '')), ''), 'unavailable')"
+    )
+
+
+def _d(col: str) -> str:
+    """SQL: parse the ``M/D/YYYY H:MM`` date column to DATE (NULL on failure)."""
+    return f"TRY_STRPTIME(split_part(\"{col}\", ' ', 1), ['%-m/%-d/%Y', '%m/%d/%Y'])::DATE"
+
+
+def _pmid(col: str) -> str:
+    """SQL: PMID as BIGINT, with 0/non-numeric → NULL."""
+    return f'nullif(TRY_CAST("{col}" AS BIGINT), 0)'
+
+
+def download_csv(version: str, settings: Settings | None = None) -> Path:
+    """Download the rolling Retraction Watch CSV into the raw layer (kept as bronze)."""
+    s = settings or get_settings()
+    dest = raw_dir(_RAW, s) / f"{version}-retraction_watch.csv"
+    return download(s.retractionwatch_url, dest)
+
+
+def _select_sql(path: Path, version: str, limit: int | None) -> str:
+    limit_sql = f" LIMIT {int(limit)}" if limit else ""
+    return f"""
+        SELECT
+            TRY_CAST("Record ID" AS BIGINT)        AS record_id,
+            "Title"                                 AS title,
+            {_arr("Subject")}                       AS subjects,
+            {_arr("Institution")}                   AS institutions,
+            "Journal"                               AS journal,
+            "Publisher"                             AS publisher,
+            {_arr("Country")}                       AS countries,
+            {_arr("Author")}                        AS authors,
+            {_arr("URLS")}                          AS urls,
+            "ArticleType"                           AS article_type,
+            {_d("RetractionDate")}                  AS retraction_date,
+            {_doi("RetractionDOI")}                 AS retraction_doi,
+            {_pmid("RetractionPubMedID")}           AS retraction_pmid,
+            {_d("OriginalPaperDate")}               AS original_paper_date,
+            {_doi("OriginalPaperDOI")}              AS original_paper_doi,
+            {_pmid("OriginalPaperPubMedID")}        AS original_paper_pmid,
+            "RetractionNature"                      AS retraction_nature,
+            {_arr("Reason")}                        AS reasons,
+            nullif(lower(trim("Paywalled")), '') = 'yes'  AS paywalled,
+            "Notes"                                 AS notes,
+            CAST({_sql_str(version)} AS VARCHAR)    AS snapshot_version
+        FROM read_csv(
+            {csv_source([path])},
+            header = true, all_varchar = true, sample_size = -1,
+            quote = '"', escape = '"', ignore_errors = true
+        )
+        WHERE TRY_CAST("Record ID" AS BIGINT) IS NOT NULL{limit_sql}
+    """
+
+
+def curate(
+    con: duckdb.DuckDBPyConnection,
+    path: Path,
+    version: str,
+    *,
+    target: str | None = None,
+    limit: int | None = None,
+) -> int:
+    """MERGE-upsert the Retraction Watch CSV into ``retractions`` on ``record_id``."""
+    target = target or f"{LAKE}.{_TABLE}"
+    return upsert(
+        con, target, _select_sql(path, version, limit),
+        key="record_id", exclude_change_cols=["snapshot_version"],
+    )
+
+
+def ingest(
+    *,
+    file: str | None = None,
+    version: str | None = None,
+    schema: str = "retractionwatch",
+    limit: int | None = None,
+    settings: Settings | None = None,
+) -> dict:
+    """End-to-end: download (unless ``file``) → MERGE-upsert → return a summary."""
+    s = settings or get_settings()
+    version = version or _today_version()
+    path = Path(file) if file else download_csv(version, s)
+    target = f"{LAKE}.{schema}.retractions"
+    con = lake_connect(s)
+    try:
+        with ops.run(con, source="retractionwatch", target=target, version=version) as r:
+            r.rows = curate(con, path, version, target=target, limit=limit)
+    finally:
+        con.close()
+    return r.summary()

--- a/tests/fixtures/retractionwatch_sample.csv
+++ b/tests/fixtures/retractionwatch_sample.csv
@@ -1,0 +1,4 @@
+Record ID,Title,Subject,Institution,Journal,Publisher,Country,Author,URLS,ArticleType,RetractionDate,RetractionDOI,RetractionPubMedID,OriginalPaperDate,OriginalPaperDOI,OriginalPaperPubMedID,RetractionNature,Reason,Paywalled,Notes
+100,"Test Title A","Biochemistry;Oncology;","Inst A;Inst B;",J Test,Pub X,"USA;China;","Doe, J;Roe, R;","http://a;http://b;",Research Article,3/20/2026 0:00,10.1/RET,111,1/2/2020 0:00,10.1/ABC,222,Retraction,"Plagiarism;Error in Data;",No,Some note
+101,Title B,,,J2,Pub Y,,,,Correction,6/15/2026 0:00,,0,,https://doi.org/10.2/XyZ,0,Correction,,Yes,
+badid,Bad,,,,,,,,,,,,,,,,,,

--- a/tests/test_retractionwatch.py
+++ b/tests/test_retractionwatch.py
@@ -1,0 +1,72 @@
+"""Offline tests for the Retraction Watch source.
+
+Curate the CSV into the tidy ``retractionwatch.retractions`` table: multi-value
+fields → arrays, M/D/YYYY date parsing, DOI normalization, PMID sentinels → NULL,
+Paywalled → bool, non-numeric key dropped, and MERGE idempotency. No network.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from cdsci.lake import Settings, lake_connect, table_exists
+from cdsci.lake.sources import retractionwatch
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture
+def lake_settings(tmp_path: Path) -> Settings:
+    return Settings(storage_base_uri=f"file://{tmp_path}")
+
+
+def test_retractionwatch_curate(lake_settings: Settings):
+    con = lake_connect(lake_settings)
+    try:
+        # 3 fixture rows; the non-numeric "Record ID" row drops.
+        n = retractionwatch.curate(
+            con, FIXTURES / "retractionwatch_sample.csv", "test-2026-06-23"
+        )
+        assert n == 2
+        assert table_exists(con, "retractions")
+
+        a = con.execute("""
+            SELECT subjects, institutions, countries, authors, reasons,
+                   retraction_date::VARCHAR, original_paper_date::VARCHAR,
+                   original_paper_doi, original_paper_pmid, retraction_pmid,
+                   retraction_nature, paywalled
+            FROM lake.retractionwatch.retractions WHERE record_id = 100
+        """).fetchone()
+        (subjects, insts, countries, authors, reasons, rdate, odate,
+         odoi, opmid, rpmid, nature, paywalled) = a
+        assert subjects == ["Biochemistry", "Oncology"]      # split, trailing ';' dropped
+        assert insts == ["Inst A", "Inst B"]
+        assert countries == ["USA", "China"]
+        assert authors == ["Doe, J", "Roe, R"]               # commas inside quoted field
+        assert reasons == ["Plagiarism", "Error in Data"]
+        assert rdate == "2026-03-20" and odate == "2020-01-02"   # M/D/YYYY parsed
+        assert odoi == "10.1/abc"                            # lowercased
+        assert opmid == 222 and rpmid == 111
+        assert nature == "Retraction" and paywalled is False
+
+        b = con.execute("""
+            SELECT original_paper_doi, original_paper_pmid, paywalled, subjects,
+                   retraction_date::VARCHAR
+            FROM lake.retractionwatch.retractions WHERE record_id = 101
+        """).fetchone()
+        odoi_b, opmid_b, paywalled_b, subjects_b, rdate_b = b
+        assert odoi_b == "10.2/xyz"        # resolver prefix stripped + lowercased
+        assert opmid_b is None             # PMID '0' → NULL
+        assert paywalled_b is True
+        assert subjects_b == []            # empty multi-value → empty array
+        assert rdate_b == "2026-06-15"
+
+        # Idempotent re-run adds no snapshot.
+        before = con.execute("SELECT max(snapshot_id) FROM lake.snapshots()").fetchone()[0]
+        retractionwatch.curate(con, FIXTURES / "retractionwatch_sample.csv", "test-2026-06-23")
+        after = con.execute("SELECT max(snapshot_id) FROM lake.snapshots()").fetchone()[0]
+        assert before == after
+    finally:
+        con.close()


### PR DESCRIPTION
Adds the **Retraction Watch** source — the roadmap's top recurring-sync candidate (CC0, weekday-daily) — as one tidy table `lake.retractionwatch.retractions`.

### Source
- Crossref-hosted rolling CSV (~70k rows), keyed `record_id`.
- Multi-value fields (subjects/authors/institutions/countries/reasons/urls) → `VARCHAR[]`; `M/D/YYYY` dates parsed; DOIs normalized (prefix-stripped, lowercased) like `openalex`; PMIDs `0`→NULL.
- `original_paper_doi` / `original_paper_pmid` are the **integrity-flag join keys** to `icite` / `reporter.publink` / `openalex` / omicidx.
- MERGE on `record_id` = the roadmap's "full-file diff"; records runs via `ops.run`; pull date is `snapshot_version` (kept bronze CSV, ADR-0005).
- CLI `run [--file|--version|--schema|--limit]`; design doc `docs/design/retractionwatch.md`; registered in the ops source registry.

### Validation
- 24 offline tests pass (arrays, date parse, DOI norm, PMID sentinels, paywalled, idempotency); ruff clean.
- **Full prod load**: 70,426 rows → `lake.retractionwatch.retractions` (ops run `success`, snapshot 453). Integrity joins confirmed: **28,938** retractions matched to iCite by PMID; **2,316** notices on NIH-grant-linked papers (→ publink). Nature: 65,205 Retraction / 3,578 EoC / 1,486 Correction / 157 Reinstatement.

Remaining (roadmap): the daily-schedule automation, and a DOI→OpenAlex crosswalk (`ref.id_crosswalk`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)