### PR TITLE
Add Reliance on Science source (patent<->paper links) [CC BY-NC]

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -47,14 +47,16 @@ All four below join cleanly off the OpenAlex hub we now have.
 
 | source | cadence | distribution | join key | license | size | ingest plan |
 |--------|---------|--------------|----------|---------|------|-------------|
-| **Reliance on Science** (patents↔papers) | versioned, ~annual (Jun–Jul); latest 2024 ed. (Zenodo rec 11461587) | Zenodo concept DOI `10.5281/zenodo.3236339`, `_pcs_oa.csv` (CSV) | **OpenAlex Work ID** (+DOI/PMID crosswalks) | **CC BY-NC 4.0** — non-commercial; flag for review | ~2.5 GB core / ~25 GB full; ~16M cites | poll concept DOI ~quarterly; infrequent recurring loader |
+| **Reliance on Science** (patents↔papers) ✅ **LANDED** | versioned, ~annual; pinned 2024 ed. (Zenodo rec 11461587) | Zenodo `_pcs_oa.csv` + `_patent_paper_pairs.csv` | **OpenAlex Work ID** | **CC BY-NC 4.0** — non-commercial, **do NOT redistribute** (license carried in `ops.source`) | ~2.5 GB | **DONE** → `reliance.patent_citations` + `reliance.patent_paper_pairs`; see `docs/design/reliance.md`, `docs/data-licenses.md` |
 | **Retraction Watch** (integrity) ✅ **LANDED** | **weekday-daily** | Crossref GitLab `crossref/retraction-watch-data`, single `retraction_watch.csv` (semicolon multi-value) | DOI (`OriginalPaperDOI`); PMID secondary — **needs DOI→OA crosswalk** | effectively CC0 | ~65 MB, ~70.6k rows | **DONE** → `lake.retractionwatch.retractions` (key `record_id`, multi-value→arrays, `ops.run`); see `docs/design/retractionwatch.md`. Daily scheduler still TODO |
 | **SciSciNet v2** (sci-of-science: disruption, etc.) | **static per version**; v2 ~spring 2025, no v3 | GCS `gs://sciscinet-neo/v2/` (Parquet); HF small tables; BigQuery (form-gated) | **OpenAlex Work ID** (v2 PaperID) | BSD-3-Clause-Clear (verify) | ~210 GB core (+1.7 TB embeddings, optional) | one-time pinned-snapshot loader; use OA directly for freshness, SciSciNet only for derived measures |
 | **PreprintToPaper** (bioRxiv/medRxiv→published) | **static**, occasional versions; v2.0.0 (2025-12-19) | Zenodo `10.5281/zenodo.17992421`, `PreprintToPaper.csv` (CSV) | DOI pairs — **no OA ids/PMIDs**, needs DOI→OA crosswalk | CC-BY-4.0 | ~617 MB, ~145.5k rows | one-shot static reference table |
 
 Notes:
-- **Only Reliance on Science is non-open** (CC BY-NC) — review before republishing in
-  the shared lake. The other three are CC0 / CC-BY / BSD.
+- **Only Reliance on Science is non-open** (CC BY-NC) — *landed* for **internal
+  non-commercial** use (state university); **never redistribute** it or derived
+  extracts. License carried forward in `ops.source` + `docs/data-licenses.md`.
+  The other candidates are CC0 / CC-BY / BSD.
 - **Retraction Watch is the one true recurring sync** here — small and daily; a good
   first customer for whatever scheduler we adopt (cron / pg_cron + LISTEN/NOTIFY).
   *(Source landed; the daily-schedule automation is the remaining piece.)*

--- a/docs/data-licenses.md
+++ b/docs/data-licenses.md
@@ -1,0 +1,30 @@
+# Data licenses — per-source terms (carry-forward)
+
+Source data in the lake carries its own license. The machine-readable record is
+the `lake_ops.source` registry — `SELECT name, license FROM ops.lake_ops.source` —
+which every ingestor seeds. This file is the human-facing summary; **check it
+before exporting or sharing any data or derived artifact.**
+
+The lake is **internal and private** (Postgres catalog + private R2); loading data
+into it is internal use, not redistribution.
+
+| source | license | redistribute? | notes |
+|--------|---------|---------------|-------|
+| reporter, icite, ctgov, scp, census_geo | US public domain | yes | US-government works |
+| openalex | CC0 | yes | public domain dedication |
+| retractionwatch | CC0 (effectively) | yes | attribution appreciated |
+| pmc | mixed OA | per-article | BioC-PMC open-access subset; honor per-article terms |
+| europepmc | Europe PMC terms | verify | confirm reuse terms before any external sharing |
+| **reliance** | **CC BY-NC 4.0** | **NO** | **non-commercial only; do NOT redistribute; attribute Marx** |
+
+## ⚠️ Non-commercial / non-redistributable sources
+
+**Reliance on Science (`reliance.*`) is CC BY-NC 4.0.** Internal non-commercial
+research use only (a state university qualifies). **Never** include `reliance.*` —
+or any view/extract/join output derived from it — in a public dataset, a shared
+download, a published figure's underlying data, or any commercial use. Attribute:
+Marx, M., *Reliance on Science* (Zenodo). See `docs/design/reliance.md`.
+
+Practical rule for consumers and export tooling: if a query touches `reliance.*`,
+its output inherits CC BY-NC — treat it as non-redistributable. When in doubt,
+read the `license` column for every source a query reads.

--- a/docs/design/reliance.md
+++ b/docs/design/reliance.md
@@ -1,0 +1,90 @@
+# Reliance on Science (`reliance`) source
+
+**Reliance on Science** (Matt Marx, Cornell) links **patents to the scientific
+papers they cite** (and same-team paper/patent pairs), resolved to **OpenAlex Work
+IDs**. It is the translational/economic-impact axis: *which research is relied upon
+by patented invention*, complementing our citation-impact metrics (RCR, disruption).
+
+## ⚠️ License — CC BY-NC 4.0 (read first)
+
+This is the **only non-open source in the lake**. It is **CC BY-NC 4.0**
+(Attribution–**NonCommercial**).
+
+- **Permitted:** internal, **non-commercial** research use. As a state university,
+  our analytical use qualifies.
+- **Required:** **attribution** — Marx, M., *Reliance on Science*, Zenodo
+  (pinned record below).
+- **Prohibited:** **redistribution.** Do **not** publish this data or any extract,
+  view, or derived table that contains it outside the institution, and do not use
+  it for commercial purposes. It lives only in the private lake (Postgres catalog +
+  private R2); it must never appear in a public/redistributable surface.
+
+**Carry-forward mechanism:** the license is recorded machine-readably in the source
+registry — `SELECT license FROM ops.lake_ops.source WHERE name='reliance'` →
+`cc-by-nc-4.0`. Consumers should check `license` before exporting anything, and any
+export tooling should refuse to include `reliance.*` (and any join output derived
+from it) in shared artifacts. Also summarized in `docs/data-licenses.md`.
+
+## Source = a pinned Zenodo record
+
+Versioned annually on Zenodo (concept DOI `10.5281/zenodo.3236339`); we pin the
+**2024 edition, record `11461587`** (`Settings.reliance_zenodo_record`) for
+reproducibility. `snapshot_version` defaults to `zenodo-<record>`. Two CSV files:
+
+| file | → table | what |
+|------|---------|------|
+| `_pcs_oa.csv` (~2.46 GB) | `reliance.patent_citations` | patent→paper **citations** |
+| `_patent_paper_pairs.csv` (~22 MB) | `reliance.patent_paper_pairs` | same-team paper/patent **matches** |
+
+## Tables (`reliance` schema)
+
+### `reliance.patent_citations` — key `(patent, work_id, reftype, wherefound)`
+
+| column | type | note |
+|--------|------|------|
+| `patent` | VARCHAR | USPTO patent id (lowercased, e.g. `us-11426570-b2`) |
+| `work_id` | VARCHAR | **`W`-form OpenAlex Work ID** (from `oaid`) → joins `openalex.works.id` |
+| `oaid` | BIGINT | raw OpenAlex numeric id |
+| `reftype` | VARCHAR | `app` (applicant) / `exam` (examiner-added) |
+| `wherefound` | VARCHAR | `frontonly` / `bodyonly` / `both` |
+| `confscore` | INTEGER | match confidence 1–10 |
+| `self_cite` | BOOLEAN | patent and paper share an author |
+| `uspto` | BOOLEAN | USPTO patent |
+| `snapshot_version` | VARCHAR | excluded from change-detection |
+
+### `reliance.patent_paper_pairs` — key `(work_id, patent)`
+
+| column | type | note |
+|--------|------|------|
+| `work_id` | VARCHAR | OpenAlex Work ID (already `W`-form) |
+| `patent` | VARCHAR | USPTO patent id (uppercased) |
+| `ppp_score` | INTEGER | pairing confidence |
+| `days_paper_to_patent` | INTEGER | days between paper and patent filing (can be negative) |
+| `all_patents_for_paper` | VARCHAR | other patents matched to the same paper |
+| `snapshot_version` | VARCHAR | |
+
+Both curate read all-varchar, normalize the OpenAlex id to `W`-form, and **GROUP BY
+the natural key** so the staged rows are unique (the citations file repeats a paper
+for front/body/applicant/examiner variants); MERGE-upsert keeps reloads to deltas.
+
+## Loading
+
+`python -m cdsci.lake.sources.reliance run` loads both files; `--dataset
+citations|pairs` loads one, `--file` a local CSV, `--limit` a smoke cap. Run via
+`ops.run`. The big `_pcs_oa.csv` (~2.46 GB, tens of millions of rows) is a long
+single MERGE — run it in the background.
+
+## Why it's useful
+
+`work_id` joins straight to `openalex.works` (once loaded), so a center's papers →
+`reliance.patent_citations` answers **"which of our research is cited by patents,
+and how much"** — a translational benchmarking signal distinct from academic
+citations. The pairs table adds **"our researchers who also patent."** DOI/PMID
+join paths to `icite`/`publink` follow once `ref.id_crosswalk` lands.
+
+## Open items
+
+- **Depends on OpenAlex** for the richest joins (`work_id` → `openalex.works`);
+  usable standalone meanwhile (patent counts per Work ID).
+- **License enforcement** is documentary + the `ops` registry flag today; an
+  export guard that refuses `reliance.*` belongs with the consumer tooling.

--- a/src/cdsci/lake/config.py
+++ b/src/cdsci/lake/config.py
@@ -127,6 +127,18 @@ class Settings(BaseSettings):
     retractionwatch_url: str = (
         "https://gitlab.com/crossref/retraction-watch-data/-/raw/main/retraction_watch.csv"
     )
+    # Reliance on Science (Marx) — patent↔paper links, keyed by OpenAlex Work ID.
+    # **CC BY-NC 4.0**: internal non-commercial use only, NOT for redistribution;
+    # the license is carried forward in the lake_ops source registry. A pinned
+    # Zenodo record (v63, 2024 ed.) for reproducibility; `_pcs_oa.csv` = patent→
+    # paper citations, `_patent_paper_pairs.csv` = same-team matched pairs.
+    reliance_zenodo_record: str = "11461587"
+    reliance_files: list[str] = ["_pcs_oa.csv", "_patent_paper_pairs.csv"]
+
+    @property
+    def reliance_base_url(self) -> str:
+        """Zenodo file-download base for the pinned Reliance on Science record."""
+        return f"https://zenodo.org/records/{self.reliance_zenodo_record}/files"
 
     @property
     def scp_releases_api(self) -> str:

--- a/src/cdsci/lake/ops.py
+++ b/src/cdsci/lake/ops.py
@@ -79,6 +79,10 @@ SOURCES: tuple[Source, ...] = (
            "monthly", "europepmc-bulk", "europepmc-terms"),
     Source("retractionwatch", "retractionwatch", "Retraction Watch retraction/correction notices",
            "weekday-daily", "crossref-gitlab-csv", "cc0", watermark_strategy="full"),
+    # CC BY-NC 4.0: internal non-commercial use only, do NOT redistribute. The
+    # license string is the machine-readable carry-forward for consumers.
+    Source("reliance", "reliance", "Reliance on Science (Marx): patent↔paper links [NC]",
+           "annual", "zenodo", "cc-by-nc-4.0"),
 )
 
 

--- a/src/cdsci/lake/sources/reliance/__init__.py
+++ b/src/cdsci/lake/sources/reliance/__init__.py
@@ -1,0 +1,11 @@
+"""Reliance on Science (Marx) — patent↔paper links, keyed by OpenAlex Work ID.
+
+**CC BY-NC 4.0** — internal non-commercial use only; do **not** redistribute. The
+license is carried forward in the ``lake_ops.source`` registry. Two tables:
+``reliance.patent_citations`` (patents citing papers) and
+``reliance.patent_paper_pairs`` (same-team matches). See ``docs/design/reliance.md``.
+"""
+
+from .ingest import DATASETS, curate, download_dataset, ingest
+
+__all__ = ["DATASETS", "curate", "download_dataset", "ingest"]

--- a/src/cdsci/lake/sources/reliance/__main__.py
+++ b/src/cdsci/lake/sources/reliance/__main__.py
@@ -1,0 +1,44 @@
+"""CLI: ``python -m cdsci.lake.sources.reliance`` — load Reliance on Science.
+
+CC BY-NC 4.0 — internal non-commercial use only; do not redistribute.
+"""
+
+from __future__ import annotations
+
+import typer
+
+from .ingest import DATASETS, ingest
+
+app = typer.Typer(
+    help="Ingest Reliance on Science (patent↔paper links) into lake.reliance.* "
+    "[CC BY-NC 4.0 — internal, non-commercial; do not redistribute].",
+    add_completion=False,
+)
+
+
+@app.callback()
+def main() -> None:
+    """Reliance on Science ingestor (keeps the ``run`` subcommand explicit)."""
+
+
+@app.command("run")
+def run(
+    dataset: str | None = typer.Option(
+        None, "--dataset", "-d", help=f"One of {list(DATASETS)}; omit for both."
+    ),
+    file: str | None = typer.Option(None, "--file", help="Local CSV for --dataset."),
+    version: str | None = typer.Option(None, "--version", help="Snapshot label."),
+    schema: str = typer.Option("reliance", "--schema", help="Target lake schema."),
+    limit: int | None = typer.Option(None, "--limit", help="Cap rows per file (smoke test)."),
+) -> None:
+    """Download + MERGE-upsert Reliance on Science into lake.reliance.*."""
+    summary = ingest(dataset=dataset, file=file, version=version, schema=schema, limit=limit)
+    delta = "changed" if summary["changed"] else "no change (idempotent)"
+    typer.echo(
+        f"lake.{schema}.* <- {summary['rows']:,} rows "
+        f"(snapshot {summary['version']}) — {delta}: {summary['counts']}"
+    )
+
+
+if __name__ == "__main__":
+    app()

--- a/src/cdsci/lake/sources/reliance/ingest.py
+++ b/src/cdsci/lake/sources/reliance/ingest.py
@@ -1,0 +1,153 @@
+"""Ingest **Reliance on Science** (Marx) — patent↔paper links — into ``lake.reliance``.
+
+> **License: CC BY-NC 4.0 (Attribution-NonCommercial).** Internal, non-commercial
+> research use only (we are a state university). **Do not redistribute** this data
+> or any extract that includes it outside the institution. Attribution: Marx, M.,
+> *Reliance on Science* (Zenodo). The constraint is carried forward in the
+> ``lake_ops.source`` registry (``license='cc-by-nc-4.0'``) — consumers can and
+> should read it. See ``docs/design/reliance.md`` and ``docs/data-licenses.md``.
+
+Two files from a pinned Zenodo record (v63, 2024 ed.), both keyed by the
+**OpenAlex Work ID** so they join straight onto ``openalex.works``:
+
+* ``_pcs_oa.csv`` → ``reliance.patent_citations`` — patents citing papers
+  (the "reliance" signal: research relied upon by patented invention).
+* ``_patent_paper_pairs.csv`` → ``reliance.patent_paper_pairs`` — same-team
+  paper/patent matches.
+
+MERGE-upsert on the natural key (ADR-0003); run recorded via ``ops.run`` (ADR-0006).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import duckdb
+
+from ... import ops
+from ...config import Settings, get_settings
+from ...connect import LAKE, csv_source, lake_connect, raw_dir, upsert
+from ...download import download
+
+_RAW = "reliance"  # raw-download subdir name
+
+
+@dataclass(frozen=True)
+class Dataset:
+    """One Reliance file → one lake table + its natural key."""
+
+    filename: str
+    table: str
+    key: list[str] = field(default_factory=list)
+
+
+DATASETS: dict[str, Dataset] = {
+    "citations": Dataset("_pcs_oa.csv", "patent_citations",
+                         ["patent", "work_id", "reftype", "wherefound"]),
+    "pairs": Dataset("_patent_paper_pairs.csv", "patent_paper_pairs",
+                     ["work_id", "patent"]),
+}
+
+
+def _sql_str(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def download_dataset(dataset: str, version: str, settings: Settings | None = None) -> Path:
+    """Download one Reliance file into the raw layer (resumably). Returns the path."""
+    s = settings or get_settings()
+    spec = DATASETS[dataset]
+    url = f"{s.reliance_base_url}/{spec.filename}"
+    dest = raw_dir(_RAW, s) / f"{version}-{spec.filename}"
+    return download(url, dest)
+
+
+def _citations_sql(path: Path, version: str, limit: int | None) -> str:
+    """patent→paper citations: normalize oaid→W-form, dedup on the natural key."""
+    limit_sql = f" LIMIT {int(limit)}" if limit else ""
+    return f"""
+        SELECT
+            lower(trim(patent))                          AS patent,
+            'W' || CAST(TRY_CAST(oaid AS BIGINT) AS VARCHAR) AS work_id,
+            TRY_CAST(oaid AS BIGINT)                     AS oaid,
+            reftype,
+            wherefound,
+            max(TRY_CAST(confscore AS INTEGER))          AS confscore,
+            bool_or(lower("self") = 'self')              AS self_cite,
+            bool_or(TRY_CAST(uspto AS INTEGER) = 1)      AS uspto,
+            CAST({_sql_str(version)} AS VARCHAR)         AS snapshot_version
+        FROM read_csv(
+            {csv_source([path])},
+            header = true, all_varchar = true, sample_size = -1, ignore_errors = true
+        )
+        WHERE TRY_CAST(oaid AS BIGINT) IS NOT NULL
+        GROUP BY patent, work_id, oaid, reftype, wherefound{limit_sql}
+    """
+
+
+def _pairs_sql(path: Path, version: str, limit: int | None) -> str:
+    """same-team paper/patent pairs: paperid is already W-form; dedup on (work_id, patent)."""
+    limit_sql = f" LIMIT {int(limit)}" if limit else ""
+    return f"""
+        SELECT
+            paperid                                      AS work_id,
+            upper(trim(patent))                          AS patent,
+            max(TRY_CAST(ppp_score AS INTEGER))          AS ppp_score,
+            max(TRY_CAST(daysdiffcont AS INTEGER))       AS days_paper_to_patent,
+            any_value(nullif(trim(all_patents_for_the_same_paper), '')) AS all_patents_for_paper,
+            CAST({_sql_str(version)} AS VARCHAR)         AS snapshot_version
+        FROM read_csv(
+            {csv_source([path])},
+            header = true, all_varchar = true, sample_size = -1, ignore_errors = true
+        )
+        WHERE nullif(trim(paperid), '') IS NOT NULL
+        GROUP BY work_id, patent{limit_sql}
+    """
+
+
+def curate(
+    con: duckdb.DuckDBPyConnection,
+    dataset: str,
+    path: Path,
+    version: str,
+    *,
+    schema: str = "reliance",
+    limit: int | None = None,
+) -> int:
+    """MERGE-upsert one Reliance dataset into its ``reliance`` table; return its row count."""
+    spec = DATASETS[dataset]
+    target = f"{LAKE}.{schema}.{spec.table}"
+    sql = _citations_sql(path, version, limit) if dataset == "citations" \
+        else _pairs_sql(path, version, limit)
+    upsert(con, target, sql, key=spec.key, exclude_change_cols=["snapshot_version"])
+    return con.execute(f"SELECT count(*) FROM {target}").fetchone()[0]
+
+
+def ingest(
+    *,
+    dataset: str | None = None,
+    file: str | None = None,
+    version: str | None = None,
+    schema: str = "reliance",
+    limit: int | None = None,
+    settings: Settings | None = None,
+) -> dict:
+    """End-to-end: download + MERGE the Reliance dataset(s). ``dataset`` loads one
+    (``citations`` | ``pairs``); ``file`` loads a local CSV for that ``dataset``;
+    omit both to load both files."""
+    s = settings or get_settings()
+    version = version or f"zenodo-{s.reliance_zenodo_record}"
+    names = [dataset] if dataset else list(DATASETS)
+
+    con = lake_connect(s)
+    try:
+        counts: dict[str, int] = {}
+        with ops.run(con, source="reliance", target=f"{LAKE}.{schema}", version=version) as r:
+            for name in names:
+                path = Path(file) if file else download_dataset(name, version, s)
+                counts[name] = curate(con, name, path, version, schema=schema, limit=limit)
+            r.rows = sum(counts.values())
+    finally:
+        con.close()
+    return {**r.summary(), "schema": schema, "counts": counts}

--- a/tests/fixtures/reliance_pairs.csv
+++ b/tests/fixtures/reliance_pairs.csv
@@ -1,0 +1,4 @@
+paperid,patent,ppp_score,daysdiffcont,all_patents_for_the_same_paper
+W2025049717,US-10000036,1,-1360,
+W4234301399,US-10000103,2,-342,US-10000103;US-10000104
+W2025049717,US-10000036,1,-1360,

--- a/tests/fixtures/reliance_pcs_oa.csv
+++ b/tests/fixtures/reliance_pcs_oa.csv
@@ -1,0 +1,6 @@
+reftype,confscore,oaid,patent,uspto,wherefound,self
+app,10,1552,us-11426570-b2,1,frontonly,notself
+exam,8,1552,us-11426570-b2,1,bodyonly,notself
+app,10,1552,us-11426570-b2,1,frontonly,notself
+app,9,2000,US-9999999-B1,1,both,self
+,,,,,,

--- a/tests/test_reliance.py
+++ b/tests/test_reliance.py
@@ -1,0 +1,67 @@
+"""Offline tests for the Reliance on Science source.
+
+Curate both files into the ``reliance`` schema: oaid→W-form normalization, key
+dedup, self/uspto booleans, patent lowercasing, the pairs table, MERGE
+idempotency, and that the CC BY-NC license is carried forward in lake_ops. No
+network.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from cdsci.lake import Settings, lake_connect, table_exists
+from cdsci.lake.sources import reliance
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture
+def lake_settings(tmp_path: Path) -> Settings:
+    return Settings(storage_base_uri=f"file://{tmp_path}")
+
+
+def test_reliance_citations_and_pairs(lake_settings: Settings):
+    con = lake_connect(lake_settings)
+    try:
+        # citations: 5 fixture rows → 3 distinct keys (one dup collapses, blank drops).
+        n = reliance.curate(con, "citations", FIXTURES / "reliance_pcs_oa.csv", "test")
+        assert n == 3
+        assert table_exists(con, "patent_citations")
+
+        row = con.execute("""
+            SELECT work_id, oaid, confscore, self_cite, uspto
+            FROM lake.reliance.patent_citations
+            WHERE patent = 'us-11426570-b2' AND reftype = 'app' AND wherefound = 'frontonly'
+        """).fetchone()
+        assert row == ("W1552", 1552, 10, False, True)   # oaid→W-form, max confscore, notself
+
+        # self-citation + patent lowercased.
+        self_row = con.execute("""
+            SELECT patent, self_cite FROM lake.reliance.patent_citations WHERE work_id = 'W2000'
+        """).fetchone()
+        assert self_row == ("us-9999999-b1", True)
+
+        # pairs: 3 rows → 2 distinct (work_id, patent).
+        assert reliance.curate(con, "pairs", FIXTURES / "reliance_pairs.csv", "test") == 2
+        pair = con.execute("""
+            SELECT ppp_score, days_paper_to_patent, all_patents_for_paper
+            FROM lake.reliance.patent_paper_pairs WHERE work_id = 'W4234301399'
+        """).fetchone()
+        assert pair == (2, -342, "US-10000103;US-10000104")
+
+        # License carried forward in the ops registry.
+        lic = con.execute(
+            "SELECT license FROM ops.lake_ops.source WHERE name = 'reliance'"
+        ).fetchone()[0]
+        assert lic == "cc-by-nc-4.0"
+
+        # Idempotent re-run of citations adds no snapshot.
+        before = con.execute("SELECT max(snapshot_id) FROM lake.snapshots()").fetchone()[0]
+        reliance.curate(con, "citations", FIXTURES / "reliance_pcs_oa.csv", "test")
+        after = con.execute("SELECT max(snapshot_id) FROM lake.snapshots()").fetchone()[0]
+        assert before == after
+    finally:
+        con.close()


### PR DESCRIPTION
Adds **Reliance on Science** (Marx) — patent↔paper links keyed to the **OpenAlex Work ID** — the translational/economic-impact axis (which research is relied upon by patented invention).

### ⚠️ License — CC BY-NC 4.0
The only non-open source in the lake. **Internal non-commercial use only** (state university qualifies); **do NOT redistribute** it or any derived extract; attribute Marx.
- **Carried forward** machine-readably: `ops.lake_ops.source.license = 'cc-by-nc-4.0'`.
- Human-facing notice: `docs/data-licenses.md` + a prominent section in `docs/design/reliance.md`.
- Stays only in the private lake (Postgres catalog + private R2); never a public/redistributable surface.

### Tables (`reliance` schema), both keyed to OpenAlex Work ID
- `reliance.patent_citations` (`_pcs_oa.csv`, ~2.46 GB): patent→paper citations; `oaid`→`W`-form, `reftype`/`wherefound`/`confscore`/`self_cite`/`uspto`; key `(patent, work_id, reftype, wherefound)`, GROUP BY dedup.
- `reliance.patent_paper_pairs` (`_patent_paper_pairs.csv`, ~22 MB): same-team matches; key `(work_id, patent)`.

Pinned Zenodo record (v63, 2024) for reproducibility; MERGE-upsert (ADR-0003); runs via `ops.run` (ADR-0006).

### Validation
- 25 offline tests pass (oaid→W normalization, key dedup, self/uspto booleans, patent casing, pairs, **license carried forward**, idempotency); ruff clean.
- Full prod load running (results added on completion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)