### PR TITLE
Add loguru logging, /data spill config, and surgical schema purge

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -43,7 +43,14 @@ cdsci-lake` and `lake_connect(read_only=True)`.
   `pmc.passages` (key `(pmcid, passage_index)`; exploded BioC passages with
   `text` + `section_type`/`passage_type`/`offset`/`infons`). API for incrementals.
   Loaded for corpus-wide mining (accession/software/CFDE FTS) — see ADR-0002 +
-  `docs/design/pmc.md`. (Full ~210 GB load in progress.)
+  `docs/design/pmc.md`. Ingest is instrumented with **loguru** (per-range
+  download/stream/curate progress + the `ops.run` lifecycle) and an opt-in
+  `--passage-batches N` spill-reducer (shards the passages explosion). A first
+  full load (8.36M docs / 974M passages, ~360 GB on R2) hit a disk-exhaustion IO
+  failure mid-run; that schema was **purged** (drop + version-scoped snapshot
+  expiry, see maintenance below) and is being **re-loaded**. DuckDB spill now
+  targets the 15 TB `/data` volume via `CU_OPENALEX_DUCKDB_TEMP_DIRECTORY`
+  (`.env`), not the 60 GB `/home` catalog disk.
 - **Europe PMC annotations** (`europepmc`) — text-mined entity mentions from the
   Europe PMC TextMinedTerms bulk (~54 same-shape per-database CSVs: uniprot, chebi,
   nct, gen, refsnp, …) collapsed into one tidy `europepmc.annotations` table, key
@@ -71,9 +78,15 @@ cdsci-lake` and `lake_connect(read_only=True)`.
   time-travel. Per-load stamps (`snapshot_version`) are excluded from change-detection
   via `exclude_change_cols`, so a monthly load rewrites only changed rows (not the
   whole table) and the stamp records each row's last-changed snapshot.
-- **DuckLake maintenance** (`cdsci.lake.maintenance`) — expire snapshots → cleanup
-  unused files (+ compact / vacuum), `dry_run` default; loud warning that expiry is
-  catalog-global.
+- **DuckLake maintenance** (`cdsci.lake.maintenance` + `python -m
+  cdsci.lake.maintenance_cli`) — expire snapshots → cleanup unused files (+ compact /
+  vacuum), `dry_run` default, loguru-logged; loud warning that `older_than` expiry is
+  catalog-global. **`purge_schema(schema)`** retires one schema surgically: it drops
+  the schema, then expires *only* the snapshots whose every change was that schema
+  (`schema_snapshot_ids`, via explicit `versions =>`), so no other publisher loses
+  time-travel. Note: files a schema shared a time window with (interleaved loads from
+  other sources) stay referenced until those neighbor snapshots also expire — full
+  R2 reclamation of such files waits for a routine global `older_than` pass.
 - **Docs**: ADR-0001 (platform charter), ADR-0002 (PMC full corpus), ADR-0003 (lake
   write semantics); designs `reporter-icite-mapping.md`, `scp.md`, `pmc.md`.
   **Tests**: 12 offline pass; ruff clean.
@@ -96,16 +109,17 @@ go straight to the source schemas. Promoted (full history):
 | `lake.scp.mortality`     | 1,034,042 | county+state cancer mortality (2026-06-01) |
 | `lake.scp.risk`          | 83,429 | behavioral-risk / screening prevalence (2026-06-01) |
 | `lake.scp.demographics`  | 3,310,984 | WIDE socio-economic table, ~44 cols (2026-06-01) |
-| `lake.pmc.documents`     | _(loading, full corpus)_ | 1 row/article: pmid/doi/license/title crosswalk (~6–12M) |
-| `lake.pmc.passages`      | _(loading, full corpus)_ | 1 row/BioC passage: text + section/type/offset (exploded) |
+| `lake.pmc.documents`     | _(re-loading)_ | 1 row/article: pmid/doi/license/title crosswalk (~8.4M); prior load purged after an IO failure |
+| `lake.pmc.passages`      | _(re-loading)_ | 1 row/BioC passage: text + section/type/offset (exploded; ~974M); re-loading with loguru + `/data` spill |
 | `lake.ref.geo_state`     | 56 | FIPS↔abbrev↔name + WKB geometry (cb 2023) |
 | `lake.ref.geo_county`    | 3,235 | 5-digit FIPS + WKB geometry (cb 2023) |
 | `lake.europepmc.annotations` | 10,288,483 | Europe PMC text-mined terms, 54 databases, key (database, accession, pmcid); 1.59M PMCIDs (snapshot 2026-06-23) |
 
 `lake_ops` (the operational ledger, ADR-0006) is live in the Postgres catalog: a
 second `ops` attachment (write-mode connects only) with `lake_ops.source` /
-`run` / `watermark` / `dataset_contract`. 5/7 ingestors + europepmc record runs
-via `ops.run`; pmc/openalex convert after their bulk loads finish.
+`run` / `watermark` / `dataset_contract`. Ingestors record runs via `ops.run`
+(pmc included — its reload brackets the load in a run row, loguru-logged); only
+openalex still converts after its bulk load finishes.
 
 **Trial↔grant↔literature triangle verified:** 70,376 trials link to 92,470 NIH
 grants via 145,811 shared publications (`ctgov.references` ⋈ `reporter.publink`);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.13"
 dependencies = [
     "duckdb>=1.5.3",
     "httpx>=0.28.1",
+    "loguru>=0.7.3",
     "pydantic-settings>=2.14.1",
     "tenacity>=9.1.4",
     "typer>=0.26.7",

--- a/src/cdsci/lake/config.py
+++ b/src/cdsci/lake/config.py
@@ -38,6 +38,11 @@ class Settings(BaseSettings):
     # --- DuckDB resource limits (bound work; spill to disk) ---
     duckdb_memory_limit: str | None = None  # None → ~70% RAM (see lake._auto_memory_limit)
     duckdb_threads: int = Field(default=4, ge=1)
+    # Where DuckDB spills when memory_limit is exceeded. Big explosions (the PMC
+    # passages unnest is the worst) can spill 100+ GB, so point this at a large
+    # volume — exhausting the catalog disk is what aborts a multi-hour load with an
+    # IO error. None → ``<storage_root>/lake/duckdb_tmp`` (dev default).
+    duckdb_temp_directory: str | None = None
 
     # --- Lake backend selection ---
     # "local"    → single-file DuckDB catalog + Parquet under the storage seam

--- a/src/cdsci/lake/connect.py
+++ b/src/cdsci/lake/connect.py
@@ -119,7 +119,11 @@ def lake_connect(
 
 def _apply_limits(con: duckdb.DuckDBPyConnection, s: Settings) -> None:
     """Bound memory/threads and spill to a local temp dir rather than OOM."""
-    tmp_dir = _local_root(s) / "lake" / "duckdb_tmp"
+    tmp_dir = (
+        Path(s.duckdb_temp_directory)
+        if s.duckdb_temp_directory
+        else _local_root(s) / "lake" / "duckdb_tmp"
+    )
     tmp_dir.mkdir(parents=True, exist_ok=True)
     con.execute(f"SET memory_limit = '{s.duckdb_memory_limit or _auto_memory_limit()}';")
     con.execute(f"SET threads = {s.duckdb_threads};")

--- a/src/cdsci/lake/log.py
+++ b/src/cdsci/lake/log.py
@@ -1,0 +1,53 @@
+"""Loguru logging for the lake substrate and its ingestors.
+
+One import — ``from .log import logger`` — and a module logs. The CLI entry
+points call :func:`configure` once to install a single stderr sink at a sane
+level (``CDSCI_LOG_LEVEL`` or ``INFO``); **library code never configures at
+import**, so a consumer that only `pip install`s the read client and calls
+:func:`cdsci.lake.lake_connect` stays quiet unless it opts in.
+
+Long bulk loads (PMC especially) are the reason this exists: the per-range
+download → stream → curate progress, the ``ops.run`` lifecycle, and maintenance
+expiry/cleanup all log here so a multi-hour run leaves a legible trail and a
+failure points at the exact range/step instead of a bare traceback.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from loguru import logger
+
+_configured = False
+
+_FORMAT = (
+    "<green>{time:YYYY-MM-DD HH:mm:ss}</green> "
+    "<level>{level: <8}</level> "
+    "<cyan>{extra[ctx]}</cyan> "
+    "<level>{message}</level>"
+)
+
+
+def configure(level: str | None = None, *, force: bool = False) -> None:
+    """Install a single stderr sink (idempotent). CLIs call this once at startup.
+
+    ``level`` defaults to ``$CDSCI_LOG_LEVEL`` then ``INFO``. Re-calls are no-ops
+    unless ``force`` — so a CLI invoking another CLI's helper can't double-sink.
+    """
+    global _configured
+    if _configured and not force:
+        return
+    logger.remove()
+    logger.configure(extra={"ctx": "-"})
+    logger.add(
+        sys.stderr,
+        level=(level or os.environ.get("CDSCI_LOG_LEVEL", "INFO")).upper(),
+        format=_FORMAT,
+        backtrace=False,
+        diagnose=False,
+    )
+    _configured = True
+
+
+__all__ = ["configure", "logger"]

--- a/src/cdsci/lake/maintenance.py
+++ b/src/cdsci/lake/maintenance.py
@@ -3,7 +3,7 @@
 Every write adds (a) a snapshot to the catalog and (b) Parquet files to R2; updates
 and deletes leave older files behind. Reclaiming space is **two ordered steps**:
 
-1. **expire snapshots** (:func:`expire_snapshots`) — invalidate old snapshots so the
+1. **expire snapshots** (:func:`expire_snapshots`) — invalidate snapshots so the
    data files they alone referenced become unreferenced.
 2. **delete unused files** (:func:`cleanup_files`) — remove data files no longer
    referenced by any live snapshot.
@@ -11,40 +11,167 @@ and deletes leave older files behind. Reclaiming space is **two ordered steps**:
 Optionally **compact** many small files into fewer large ones first
 (:func:`compact`). Every step supports ``dry_run`` to preview.
 
-⚠️  These operate on the **whole catalog**, across *all* publishers (omicidx and
-every source). Expiring snapshots destroys time-travel for everyone, so on the
-shared lake it must be a coordinated, deliberate operation — never a casual run.
-Prefer ``dry_run=True`` first, and scope ``older_than`` conservatively.
+⚠️  ``older_than`` expiry operates on the **whole catalog**, across *all* publishers
+(omicidx and every source), and destroys time-travel for everyone — on the shared
+lake it must be a coordinated, deliberate operation, never a casual run.
+
+To retire **one schema** without touching anyone else's history, use
+:func:`purge_schema` (or its parts): it drops the schema, then expires *only* the
+snapshots whose every change was that schema (:func:`schema_snapshot_ids`, by
+explicit ``versions``), then cleans the now-unreferenced files. That is how the
+broken PMC load is rolled back without disturbing omicidx/openalex time-travel.
 """
 
 from __future__ import annotations
 
+import re
+
 import duckdb
 
+from .config import Settings, get_settings
 from .connect import LAKE
+from .log import logger
 
 
 def _bool(value: bool) -> str:
     return "true" if value else "false"
 
 
+# --- Per-schema snapshot resolution (the safe, surgical path) ---
+
+
+def _attach_metadata(con: duckdb.DuckDBPyConnection, settings: Settings | None, alias: str) -> str:
+    """Attach the DuckLake **metadata** Postgres DB read-only as ``alias``; return it.
+
+    The catalog metadata (``ducklake_schema`` / ``ducklake_table`` /
+    ``ducklake_snapshot_changes``, in the ``public`` schema) is what maps a change
+    log entry back to a schema — the ``ducklake_*`` functions don't expose dropped
+    tables or schema names. This is the shared Postgres lake only.
+    """
+    s = settings or get_settings()
+    if s.lake_backend != "postgres":
+        raise NotImplementedError("schema-scoped expiry targets the shared postgres lake.")
+    con.execute(
+        f"ATTACH 'dbname={s.lake_pg_dbname} host={s.lake_pg_host} port={s.lake_pg_port} "
+        f"user={s.lake_pg_user}' AS {alias} (TYPE postgres, READ_ONLY);"
+    )
+    return alias
+
+
+_SCHEMA_TOK = re.compile(r'(?:created|dropped)_schema:"([^"]+)"')
+_TABLE_NAME_TOK = re.compile(r'(?:created|dropped|altered)_table:"([^"]+)"\."[^"]+"')
+_TABLE_ID_TOK = re.compile(r"(?:inserted_into|deleted_from|compacted|altered)_table:(\d+)")
+
+
+def schema_snapshot_ids(
+    con: duckdb.DuckDBPyConnection,
+    schema: str,
+    *,
+    settings: Settings | None = None,
+) -> list[int]:
+    """Snapshot ids whose **every** change belongs to ``schema`` — safe to expire alone.
+
+    A snapshot qualifies only when all of its change-log entries name ``schema``
+    (by schema name or by one of the schema's table ids, current *or dropped*). A
+    snapshot that also touched another publisher's table is excluded, so expiring
+    the returned set can never drop another schema's time-travel. Ids ascending.
+    """
+    alias = "_md"
+    self_attached = alias not in {r[0] for r in con.execute("PRAGMA database_list").fetchall()}
+    if self_attached:
+        _attach_metadata(con, settings, alias)
+    try:
+        schema_id = con.execute(
+            f"SELECT schema_id FROM {alias}.public.ducklake_schema WHERE schema_name = ?",
+            [schema],
+        ).fetchone()
+        if schema_id is None:
+            return []
+        table_ids = {
+            r[0]
+            for r in con.execute(
+                f"SELECT table_id FROM {alias}.public.ducklake_table WHERE schema_id = ?",
+                [schema_id[0]],
+            ).fetchall()
+        }
+        rows = con.execute(
+            f"SELECT snapshot_id, changes_made FROM {alias}.public.ducklake_snapshot_changes "
+            "ORDER BY snapshot_id"
+        ).fetchall()
+    finally:
+        if self_attached:
+            con.execute(f"DETACH {alias};")
+
+    out: list[int] = []
+    for snap, changes in rows:
+        text = changes or ""
+        schemas = set(_SCHEMA_TOK.findall(text))
+        names = set(_TABLE_NAME_TOK.findall(text))
+        ids = {int(x) for x in _TABLE_ID_TOK.findall(text)}
+        touches = (schema in schemas) or (schema in names) or bool(ids & table_ids)
+        if not touches:
+            continue
+        other = (schemas - {schema}) or (names - {schema}) or (ids - table_ids)
+        if other:
+            logger.warning(
+                "snapshot {} touches {} AND others {} — not expiring", snap, schema, other
+            )
+            continue
+        out.append(snap)
+    return out
+
+
+# --- Primitive operations ---
+
+
+def drop_schema(con: duckdb.DuckDBPyConnection, schema: str, *, cascade: bool = True) -> None:
+    """``DROP SCHEMA lake.<schema>`` — remove it from the live catalog head.
+
+    The data files survive (older snapshots still reference them) until they are
+    expired and cleaned — see :func:`purge_schema`.
+    """
+    cascade_sql = " CASCADE" if cascade else ""
+    logger.warning("DROP SCHEMA {}.{}{}", LAKE, schema, cascade_sql)
+    con.execute(f"DROP SCHEMA IF EXISTS {LAKE}.{schema}{cascade_sql};")
+    logger.info("dropped schema {}.{}", LAKE, schema)
+
+
 def expire_snapshots(
     con: duckdb.DuckDBPyConnection,
     *,
     older_than: str | None = None,
+    versions: list[int] | None = None,
     dry_run: bool = True,
 ) -> list[tuple]:
-    """Invalidate snapshots older than ``older_than`` (a ``'YYYY-MM-DD[ HH:MM:SS]'``).
+    """Invalidate snapshots — by explicit ``versions`` (surgical) or ``older_than``.
 
-    Returns the affected snapshots. ``older_than`` is required for safety — with
-    no bound this would target the entire history. Run ``dry_run`` first.
+    Pass ``versions`` (a list of snapshot ids) to expire exactly those — the safe
+    way to retire one schema's snapshots without touching the rest of the catalog.
+    ``older_than`` (a ``'YYYY-MM-DD[ HH:MM:SS]'``) expires everything older, across
+    *all* publishers — global and destructive. Exactly one is required. Run
+    ``dry_run`` first.
     """
-    if not older_than:
-        raise ValueError("expire_snapshots requires older_than (no unbounded expiry).")
-    return con.execute(
-        f"CALL ducklake_expire_snapshots('{LAKE}', "
-        f"older_than => TIMESTAMP '{older_than}', dry_run => {_bool(dry_run)})"
+    if bool(versions) == bool(older_than):
+        raise ValueError("pass exactly one of versions= or older_than=.")
+    if versions is not None and not versions:
+        logger.info("expire_snapshots: empty versions list — nothing to do")
+        return []
+    if versions is not None:
+        arg = f"versions => [{', '.join(str(int(v)) for v in versions)}]"
+        logger.warning(
+            "expire_snapshots versions=[{} ids: {}…{}] dry_run={}",
+            len(versions), min(versions), max(versions), dry_run,
+        )
+    else:
+        arg = f"older_than => TIMESTAMP '{older_than}'"
+        logger.warning("expire_snapshots older_than={!r} (GLOBAL) dry_run={}", older_than, dry_run)
+    rows = con.execute(
+        f"CALL ducklake_expire_snapshots('{LAKE}', {arg}, dry_run => {_bool(dry_run)})"
     ).fetchall()
+    logger.info(
+        "expire_snapshots: {} snapshot(s) {}", len(rows), "previewed" if dry_run else "expired"
+    )
+    return rows
 
 
 def cleanup_files(
@@ -59,15 +186,57 @@ def cleanup_files(
     the safe companion to :func:`expire_snapshots` and does not itself drop
     history. Returns the files cleaned (or that would be, under ``dry_run``).
     """
-    return con.execute(
+    rows = con.execute(
         f"CALL ducklake_cleanup_old_files('{LAKE}', "
         f"cleanup_all => {_bool(cleanup_all)}, dry_run => {_bool(dry_run)})"
     ).fetchall()
+    logger.info("cleanup_files: {} file(s) {}", len(rows), "previewed" if dry_run else "deleted")
+    return rows
 
 
 def compact(con: duckdb.DuckDBPyConnection) -> list[tuple]:
     """Merge adjacent small data files into fewer larger ones (compaction)."""
-    return con.execute(f"CALL ducklake_merge_adjacent_files('{LAKE}')").fetchall()
+    logger.info("compacting adjacent files in {}", LAKE)
+    rows = con.execute(f"CALL ducklake_merge_adjacent_files('{LAKE}')").fetchall()
+    logger.info("compact: {} merge result row(s)", len(rows))
+    return rows
+
+
+def purge_schema(
+    con: duckdb.DuckDBPyConnection,
+    schema: str,
+    *,
+    settings: Settings | None = None,
+    dry_run: bool = True,
+) -> dict:
+    """Retire one schema fully: drop it, expire **only its** snapshots, clean its files.
+
+    The surgical alternative to a global ``older_than`` expiry. Resolves the
+    schema's data-bearing snapshots *before* dropping (:func:`schema_snapshot_ids`),
+    drops the schema so its files leave the head, expires exactly those snapshot
+    versions, then deletes the now-unreferenced files. Other publishers' snapshots
+    are never in the expire set. ``dry_run`` previews the snapshot set and the file
+    cleanup without dropping or expiring anything.
+    """
+    ids = schema_snapshot_ids(con, schema, settings=settings)
+    logger.info(
+        "purge_schema {}: {} data-bearing snapshot(s) resolved{}",
+        schema, len(ids), f" ({min(ids)}…{max(ids)})" if ids else "",
+    )
+    if dry_run:
+        logger.info("purge_schema {}: DRY RUN — not dropping/expiring", schema)
+        preview = expire_snapshots(con, versions=ids, dry_run=True) if ids else []
+        return {"schema": schema, "snapshots": ids, "expired": 0, "deleted": 0,
+                "previewed_expire": len(preview), "dry_run": True}
+    drop_schema(con, schema, cascade=True)
+    expired = expire_snapshots(con, versions=ids, dry_run=False) if ids else []
+    deleted = cleanup_files(con, cleanup_all=True, dry_run=False)
+    logger.success(
+        "purge_schema {}: dropped, {} snapshot(s) expired, {} file(s) deleted",
+        schema, len(expired), len(deleted),
+    )
+    return {"schema": schema, "snapshots": ids, "expired": len(expired),
+            "deleted": len(deleted), "dry_run": False}
 
 
 def vacuum(

--- a/src/cdsci/lake/maintenance_cli.py
+++ b/src/cdsci/lake/maintenance_cli.py
@@ -1,0 +1,99 @@
+"""CLI: ``python -m cdsci.lake.maintenance_cli`` — DuckLake space reclamation.
+
+Admin surface for the maintenance primitives (expire / cleanup / compact) plus
+the surgical :func:`cdsci.lake.maintenance.purge_schema` used to roll back a
+single schema (e.g. a broken PMC load) without disturbing any other publisher's
+time-travel. Every command logs via loguru and defaults to ``--dry-run`` for the
+destructive ones — pass ``--no-dry-run`` to actually mutate the shared lake.
+"""
+
+from __future__ import annotations
+
+import typer
+
+from . import maintenance
+from .connect import lake_connect, snapshots
+from .log import configure, logger
+
+app = typer.Typer(
+    help="DuckLake maintenance: expire snapshots, clean files, purge a schema.",
+    add_completion=False,
+)
+
+
+@app.callback()
+def _main(log_level: str = typer.Option("INFO", "--log-level", help="loguru level.")) -> None:
+    configure(log_level)
+
+
+@app.command("snapshots")
+def snapshots_cmd(limit: int = typer.Option(20, "--limit", help="Show the most recent N.")) -> None:
+    """List the lake's snapshots (newest last)."""
+    con = lake_connect(read_only=True)
+    try:
+        rows = snapshots(con)
+    finally:
+        con.close()
+    for r in rows[-limit:]:
+        typer.echo(f"  {r}")
+    typer.echo(f"  ({len(rows)} snapshots total)")
+
+
+@app.command("schema-snapshots")
+def schema_snapshots_cmd(schema: str = typer.Argument(..., help="Schema name, e.g. pmc.")) -> None:
+    """List the snapshot ids whose every change belongs to SCHEMA (expire-safe set)."""
+    con = lake_connect()
+    try:
+        ids = maintenance.schema_snapshot_ids(con, schema)
+    finally:
+        con.close()
+    typer.echo(f"{schema}: {len(ids)} snapshot(s)" + (f" [{min(ids)}…{max(ids)}]" if ids else ""))
+    typer.echo(f"  {ids}")
+
+
+@app.command("purge-schema")
+def purge_schema_cmd(
+    schema: str = typer.Argument(..., help="Schema to retire fully, e.g. pmc."),
+    dry_run: bool = typer.Option(True, "--dry-run/--no-dry-run", help="Preview vs. execute."),
+) -> None:
+    """Drop SCHEMA, expire only its snapshots, and clean its files (surgical rollback)."""
+    con = lake_connect()
+    try:
+        result = maintenance.purge_schema(con, schema, dry_run=dry_run)
+    finally:
+        con.close()
+    logger.info("purge-schema result: {}", result)
+    typer.echo(result)
+
+
+@app.command("cleanup")
+def cleanup_cmd(
+    dry_run: bool = typer.Option(True, "--dry-run/--no-dry-run", help="Preview vs. execute."),
+) -> None:
+    """Delete data files no longer referenced by any live snapshot."""
+    con = lake_connect()
+    try:
+        rows = maintenance.cleanup_files(con, cleanup_all=True, dry_run=dry_run)
+    finally:
+        con.close()
+    typer.echo(f"{'would delete' if dry_run else 'deleted'} {len(rows)} file(s)")
+
+
+@app.command("vacuum")
+def vacuum_cmd(
+    older_than: str = typer.Option(
+        None, "--older-than", help="GLOBAL expiry cutoff (affects all sources!)."
+    ),
+    dry_run: bool = typer.Option(True, "--dry-run/--no-dry-run", help="Preview vs. execute."),
+) -> None:
+    """Compact → (optionally GLOBAL-expire) → clean. Omit --older-than to skip expiry."""
+    con = lake_connect()
+    try:
+        out = maintenance.vacuum(con, older_than=older_than, dry_run=dry_run)
+    finally:
+        con.close()
+    typer.echo(out)
+
+
+if __name__ == "__main__":
+    app()

--- a/src/cdsci/lake/ops.py
+++ b/src/cdsci/lake/ops.py
@@ -34,6 +34,7 @@ from typing import Any
 import duckdb
 
 from .connect import LAKE
+from .log import logger
 
 OPS = "ops"  # the ATTACH alias for the ledger database
 OPS_SCHEMA = "lake_ops"
@@ -207,6 +208,11 @@ def run(
         "VALUES (?, ?, ?, ?, 'running', ?, current_timestamp, ?)",
         [rid, source, target, version, before, host],
     )
+    bound = logger.bind(ctx=f"run:{source}")
+    bound.info(
+        "start → {} (version={}, snapshot_before={}, run_id={})",
+        target, version, before, rid,
+    )
     r = Run(con, rid, source, target, version, before)
     try:
         yield r
@@ -218,6 +224,10 @@ def run(
             [after, r.rows, str(exc)[:2000], rid],
         )
         r.snapshot_after, r.status = after, "error"
+        bound.error(
+            "ERROR after {} rows (snapshot {}→{}, run_id={}): {}",
+            r.rows, before, after, rid, exc,
+        )
         raise
     else:
         after = _max_snapshot(con)
@@ -228,6 +238,10 @@ def run(
             [status, after, r.rows, rid],
         )
         r.snapshot_after, r.status = after, status
+        bound.success(
+            "{} → {} (rows={}, snapshot {}→{}, run_id={})",
+            status, target, r.rows, before, after, rid,
+        )
 
 
 def last_run(

--- a/src/cdsci/lake/sources/pmc/__main__.py
+++ b/src/cdsci/lake/sources/pmc/__main__.py
@@ -4,12 +4,18 @@ from __future__ import annotations
 
 import typer
 
+from ...log import configure
 from .ingest import ingest, list_ranges
 
 app = typer.Typer(
     help="Ingest BioC-PMC full text into lake.pmc.documents + lake.pmc.passages.",
     add_completion=False,
 )
+
+
+@app.callback()
+def _main(log_level: str = typer.Option("INFO", "--log-level", help="loguru level.")) -> None:
+    configure(log_level)
 
 
 @app.command("ranges")
@@ -40,11 +46,16 @@ def run(
     keep_raw: bool = typer.Option(
         False, "--keep-raw", help="Keep the local tarball + NDJSON per range (default: delete)."
     ),
+    passage_batches: int = typer.Option(
+        1, "--passage-batches",
+        help="Split the passages explosion into N pmcid shards (append mode) to cap spill.",
+    ),
 ) -> None:
     """Download (unless --file) BioC-PMC into pmc.documents + pmc.passages, per range."""
     s = ingest(
         ranges=range_ or None, file=file, schema=schema,
         snapshot=snapshot, mode=mode, limit=limit, keep_raw=keep_raw,
+        passage_batches=passage_batches,
     )
     typer.echo(
         f"{s['schema']} <- documents={s['documents']:,} passages={s['passages']:,}; "

--- a/src/cdsci/lake/sources/pmc/ingest.py
+++ b/src/cdsci/lake/sources/pmc/ingest.py
@@ -36,11 +36,14 @@ from ... import ops
 from ...config import Settings, get_settings
 from ...connect import LAKE, csv_source, lake_connect, raw_dir, upsert
 from ...download import download
+from ...log import logger
 
 _DOCUMENTS = "documents"
 _PASSAGES = "passages"
 _DOC = "$.documents[0]"
 _P0 = f"{_DOC}.passages[0]"
+
+_log = logger.bind(ctx="pmc")
 
 
 def list_ranges(settings: Settings | None = None) -> list[str]:
@@ -48,13 +51,18 @@ def list_ranges(settings: Settings | None = None) -> list[str]:
     s = settings or get_settings()
     html = httpx.get(s.biocpmc_ftp, timeout=60, follow_redirects=True).text
     pattern = rf"PMC\d+XXXXX_{re.escape(s.biocpmc_variant)}\.tar\.gz"
-    return sorted(set(re.findall(pattern, html)))
+    found = sorted(set(re.findall(pattern, html)))
+    _log.info("discovered {} json-unicode range tarballs on the BioC-PMC FTP", len(found))
+    return found
 
 
 def download_range(filename: str, settings: Settings | None = None) -> Path:
     """Download one range tarball to the raw layer (resumable)."""
     s = settings or get_settings()
-    return download(s.biocpmc_ftp + filename, raw_dir("pmc", s) / filename)
+    _log.info("downloading range {}", filename)
+    path = download(s.biocpmc_ftp + filename, raw_dir("pmc", s) / filename)
+    _log.info("downloaded {} ({:.1f} GB)", filename, path.stat().st_size / 1024**3)
+    return path
 
 
 def tar_to_ndjson(tar_path: Path, ndjson_path: Path) -> int:
@@ -64,6 +72,7 @@ def tar_to_ndjson(tar_path: Path, ndjson_path: Path) -> int:
     ``.ndjson.gz`` directly.
     """
     n = 0
+    skipped = 0
     opener = gzip.open if str(ndjson_path).endswith(".gz") else open
     with tarfile.open(tar_path, "r:gz") as tf, opener(ndjson_path, "wt") as out:
         for member in tf:
@@ -75,9 +84,11 @@ def tar_to_ndjson(tar_path: Path, ndjson_path: Path) -> int:
             try:
                 obj = json.loads(fh.read())
             except (ValueError, UnicodeDecodeError):
+                skipped += 1
                 continue  # skip a malformed file rather than abort the range
             out.write(json.dumps(obj, separators=(",", ":")) + "\n")
             n += 1
+    _log.info("streamed {} → {} articles ({} malformed skipped)", tar_path.name, n, skipped)
     return n
 
 
@@ -100,6 +111,7 @@ def materialize_raw(con: duckdb.DuckDBPyConnection, ndjson: Path | str) -> Path:
         ) TO '{raw}' (FORMAT parquet);
         """
     )
+    _log.info("materialized bronze {} ({:.1f} GB)", raw.name, raw.stat().st_size / 1024**3)
     return raw
 
 
@@ -123,20 +135,32 @@ def _documents_sql(src: str, snapshot: str, limit: int | None) -> str:
     """
 
 
-def _passages_sql(src: str, snapshot: str, limit: int | None) -> str:
+def _passages_sql(
+    src: str, snapshot: str, limit: int | None, *, batch: tuple[int, int] | None = None
+) -> str:
     """One row per BioC passage, exploded from the nested ``record`` array.
 
     ``passages`` is cast to a list of JSON values, then zipped against its index
     range so each passage becomes ``(pmcid, passage_index)`` — the composite key.
     The full passage ``infons`` is kept as JSON so nothing passage-level is lost.
+
+    ``batch=(i, n)`` restricts the **bronze read** to the ``i``-th of ``n`` pmcid
+    shards (``hash(pmcid) % n = i``). Filtering before the unnest is what bounds
+    peak memory: only 1/n of the range's documents are exploded per pass, so the
+    passages spill stays a fraction of the whole-range explosion.
     """
+    where = []
+    if batch is not None:
+        i, n = batch
+        where.append(f"(hash(pmcid) % {int(n)}) = {int(i)}")
+    where_sql = (" WHERE " + " AND ".join(where)) if where else ""
     limit_sql = f" LIMIT {int(limit)}" if limit else ""
     return f"""
         WITH docs AS (
             SELECT
                 pmcid,
                 CAST(json_extract(record, '{_DOC}.passages') AS JSON[]) AS passages
-            FROM read_parquet({src}){limit_sql}
+            FROM read_parquet({src}){where_sql}{limit_sql}
         ),
         exploded AS (
             SELECT
@@ -192,6 +216,7 @@ def curate(
     snapshot: str = "bulk",
     limit: int | None = None,
     mode: str = "merge",
+    passage_batches: int = 1,
 ) -> dict:
     """Load ``pmc.documents`` + ``pmc.passages`` from one bronze Parquet.
 
@@ -199,6 +224,11 @@ def curate(
     is one row per article (key ``pmcid``); ``passages`` explodes the nested BioC
     passages into one row each (key ``(pmcid, passage_index)``). Returns the row
     counts keyed by table. See :func:`_load` for ``mode`` semantics.
+
+    ``passage_batches`` > 1 (append mode only) splits the passages explosion into
+    that many pmcid shards, each its own INSERT — a spill-reduction lever for the
+    bulk load (peak memory ≈ whole-range / passage_batches). Default 1 is the
+    original single-INSERT behavior; each shard is a separate snapshot.
     """
     src = csv_source(str(raw_parquet))
     documents = _load(
@@ -208,13 +238,24 @@ def curate(
         ["pmcid"],
         mode=mode,
     )
-    passages = _load(
-        con,
-        f"{LAKE}.{schema}.{_PASSAGES}",
-        _passages_sql(src, snapshot, limit),
-        ["pmcid", "passage_index"],
-        mode=mode,
-    )
+    _log.info("documents: {:,} rows ({} mode)", documents, mode)
+
+    target = f"{LAKE}.{schema}.{_PASSAGES}"
+    if mode == "append" and passage_batches > 1:
+        passages = 0
+        for i in range(passage_batches):
+            n = _load(
+                con, target,
+                _passages_sql(src, snapshot, limit, batch=(i, passage_batches)),
+                ["pmcid", "passage_index"], mode=mode,
+            )
+            passages += n
+            _log.info("passages shard {}/{}: {:,} rows (cumulative {:,})",
+                      i + 1, passage_batches, n, passages)
+    else:
+        passages = _load(con, target, _passages_sql(src, snapshot, limit),
+                         ["pmcid", "passage_index"], mode=mode)
+        _log.info("passages: {:,} rows ({} mode)", passages, mode)
     return {"documents": documents, "passages": passages}
 
 
@@ -227,6 +268,7 @@ def ingest(
     limit: int | None = None,
     mode: str = "merge",
     keep_raw: bool = False,
+    passage_batches: int = 1,
     settings: Settings | None = None,
 ) -> dict:
     """Load BioC-PMC into ``pmc.documents`` + ``pmc.passages``, one range at a time.
@@ -249,21 +291,34 @@ def ingest(
     try:
         with ops.run(con, source="pmc", target=f"{LAKE}.{schema}", version=snapshot) as r:
             if file:
+                _log.info("loading single file {} (mode={}, schema={})", file, mode, schema)
                 raw = Path(file) if str(file).endswith(".parquet") else materialize_raw(con, file)
-                counts = curate(con, raw, schema=schema, snapshot=snapshot, limit=limit, mode=mode)
+                counts = curate(con, raw, schema=schema, snapshot=snapshot, limit=limit,
+                                mode=mode, passage_batches=passage_batches)
                 summary["documents"] += counts["documents"]
                 summary["passages"] += counts["passages"]
                 summary["ranges"].append(Path(file).name)
             else:
-                for filename in ranges if ranges is not None else list_ranges(s):
+                todo = ranges if ranges is not None else list_ranges(s)
+                _log.info("loading {} range(s) into {}.{} (mode={}, passage_batches={})",
+                          len(todo), LAKE, schema, mode, passage_batches)
+                for idx, filename in enumerate(todo, 1):
+                    _log.info("=== range {}/{}: {} ===", idx, len(todo), filename)
                     tar = download_range(filename, s)
                     ndjson = raw_dir("pmc", s) / (filename.replace(".tar.gz", ".ndjson.gz"))
                     n_files = tar_to_ndjson(tar, ndjson)
                     raw = materialize_raw(con, ndjson)
-                    counts = curate(con, raw, schema=schema, snapshot=snapshot, limit=limit, mode=mode)
+                    counts = curate(con, raw, schema=schema, snapshot=snapshot, limit=limit,
+                                    mode=mode, passage_batches=passage_batches)
                     summary["documents"] += counts["documents"]
                     summary["passages"] += counts["passages"]
                     summary["ranges"].append({"file": filename, "articles": n_files, **counts})
+                    _log.success(
+                        "range {}/{} done: {} → documents={:,} passages={:,} "
+                        "(running totals documents={:,} passages={:,})",
+                        idx, len(todo), filename, counts["documents"], counts["passages"],
+                        summary["documents"], summary["passages"],
+                    )
                     if not keep_raw:
                         # The silver tables on R2 are the faithful copy, so the local
                         # tarball / NDJSON / bronze Parquet are all transient — delete

--- a/uv.lock
+++ b/uv.lock
@@ -39,6 +39,7 @@ source = { editable = "." }
 dependencies = [
     { name = "duckdb" },
     { name = "httpx" },
+    { name = "loguru" },
     { name = "pydantic-settings" },
     { name = "tenacity" },
     { name = "typer" },
@@ -64,6 +65,7 @@ requires-dist = [
     { name = "duckdb", specifier = ">=1.5.3" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "httpx", marker = "extra == 'ingest'", specifier = ">=0.28.1" },
+    { name = "loguru", specifier = ">=0.7.3" },
     { name = "pydantic-settings", specifier = ">=2.14.1" },
     { name = "pytz", marker = "extra == 'ingest'", specifier = ">=2025.1" },
     { name = "tenacity", specifier = ">=9.1.4" },
@@ -173,6 +175,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "loguru"
+version = "0.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595, upload-time = "2024-12-06T11:20:54.538Z" },
 ]
 
 [[package]]
@@ -444,4 +459,13 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "win32-setctime"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
 ]


### PR DESCRIPTION
## Summary
Hardens the PMC full-text load (which hit a disk-exhaustion IO failure) and adds the tooling to roll it back cleanly.

- **loguru logging throughout** — new `cdsci.lake.log` (single sink, CLI-configured so the read client stays quiet; `loguru` is now a base dep). Instrumented PMC ingest (per-range download → stream → materialize → curate + running totals), `ops.run` lifecycle (start / success / idempotent / error with rows + snapshot deltas), and `maintenance`.
- **Spill off the catalog disk** — new `Settings.duckdb_temp_directory` (`CU_OPENALEX_DUCKDB_TEMP_DIRECTORY`). The PMC passages `unnest` spills 100+ GB; spilling onto the small `/home` catalog disk is what aborted the original load with an IO error.
- **Surgical schema purge** — `maintenance.purge_schema()` drops a schema, then expires **only the snapshots whose every change was that schema** (`schema_snapshot_ids` → version-targeted `expire_snapshots(versions=...)`), then cleans files — no other publisher loses time-travel. New `maintenance_cli` (`snapshots` / `schema-snapshots` / `purge-schema` / `cleanup` / `vacuum`).
- **PMC spill lever** — opt-in `--passage-batches N` shards the passages explosion to ~1/N peak memory (append mode); default `1` is unchanged behavior.

## Used in production
The broken `lake.pmc` (8.36M docs / 974M passages) was purged with `purge_schema` (drop + 60 pmc-only snapshots expired + cleanup); other sources' snapshots untouched. Re-load is in progress with the new logging + `/data` spill.

## Test plan
- `uv run ruff check src/ tests/` — clean
- `uv run pytest -q` — 25 passed, 3 skipped
- Verified live: `ops.run` + PMC loguru trail during the re-load; `purge-schema --dry-run` resolved exactly the 60 pmc-only snapshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)