### PR TITLE
Make PMC load snapshots self-describing (ADR-0007)

### DIFF
--- a/src/cdsci/lake/ops.py
+++ b/src/cdsci/lake/ops.py
@@ -173,6 +173,39 @@ class Run:
             "status": self.status,
         }
 
+    @contextmanager
+    def attribute(self, op: str, *, message: str | None = None) -> Iterator[None]:
+        """Wrap the enclosed write(s) in one **self-describing** DuckLake snapshot.
+
+        Opens a transaction, stamps the snapshot it will produce with
+        ``author='cdsci:<source>'``, a ``commit_message``, and a JSON
+        ``commit_extra_info`` (``{writer, source, target, version, run_id, op}``)
+        via ``set_commit_message``, runs the block, and commits. So the catalog
+        itself attributes the snapshot — no ledger join, no table-id resolution
+        (ADR-0007). One snapshot per block; the block rolls back on error.
+
+        ``op`` is the sub-step label (e.g. ``"documents"``, ``"passages.shard2"``).
+        Each block is its own transaction, so do **not** wrap an unbounded write in
+        one block expecting it to stay small — keep the per-block write bounded
+        (the PMC passages shards are sized for exactly this).
+        """
+        extra = json.dumps({
+            "writer": "cdsci", "source": self.source, "target": self.target,
+            "version": self.version, "run_id": self.run_id, "op": op,
+        })
+        self.con.execute("BEGIN;")
+        self.con.execute(
+            f"CALL {LAKE}.set_commit_message(?, ?, extra_info => ?);",
+            [f"cdsci:{self.source}", message or f"{self.source}: {op}", extra],
+        )
+        try:
+            yield
+        except BaseException:
+            self.con.execute("ROLLBACK;")
+            raise
+        else:
+            self.con.execute("COMMIT;")
+
 
 def _max_snapshot(con: duckdb.DuckDBPyConnection) -> int | None:
     """Current max DuckLake snapshot id, or None on an empty lake."""

--- a/src/cdsci/lake/sources/pmc/ingest.py
+++ b/src/cdsci/lake/sources/pmc/ingest.py
@@ -27,6 +27,7 @@ import gzip
 import json
 import re
 import tarfile
+from contextlib import nullcontext
 from pathlib import Path
 
 import duckdb
@@ -217,6 +218,7 @@ def curate(
     limit: int | None = None,
     mode: str = "merge",
     passage_batches: int = 1,
+    run: ops.Run | None = None,
 ) -> dict:
     """Load ``pmc.documents`` + ``pmc.passages`` from one bronze Parquet.
 
@@ -229,32 +231,42 @@ def curate(
     that many pmcid shards, each its own INSERT — a spill-reduction lever for the
     bulk load (peak memory ≈ whole-range / passage_batches). Default 1 is the
     original single-INSERT behavior; each shard is a separate snapshot.
+
+    ``run`` (the live :class:`ops.Run`) makes each write a **self-describing**
+    snapshot via :meth:`ops.Run.attribute` (ADR-0007); without it the writes run
+    unattributed (the original behavior, used by tests).
     """
+    def attr(op: str):
+        return run.attribute(op) if run is not None else nullcontext()
+
     src = csv_source(str(raw_parquet))
-    documents = _load(
-        con,
-        f"{LAKE}.{schema}.{_DOCUMENTS}",
-        _documents_sql(src, snapshot, limit),
-        ["pmcid"],
-        mode=mode,
-    )
+    with attr("documents"):
+        documents = _load(
+            con,
+            f"{LAKE}.{schema}.{_DOCUMENTS}",
+            _documents_sql(src, snapshot, limit),
+            ["pmcid"],
+            mode=mode,
+        )
     _log.info("documents: {:,} rows ({} mode)", documents, mode)
 
     target = f"{LAKE}.{schema}.{_PASSAGES}"
     if mode == "append" and passage_batches > 1:
         passages = 0
         for i in range(passage_batches):
-            n = _load(
-                con, target,
-                _passages_sql(src, snapshot, limit, batch=(i, passage_batches)),
-                ["pmcid", "passage_index"], mode=mode,
-            )
+            with attr(f"passages.shard{i + 1}/{passage_batches}"):
+                n = _load(
+                    con, target,
+                    _passages_sql(src, snapshot, limit, batch=(i, passage_batches)),
+                    ["pmcid", "passage_index"], mode=mode,
+                )
             passages += n
             _log.info("passages shard {}/{}: {:,} rows (cumulative {:,})",
                       i + 1, passage_batches, n, passages)
     else:
-        passages = _load(con, target, _passages_sql(src, snapshot, limit),
-                         ["pmcid", "passage_index"], mode=mode)
+        with attr("passages"):
+            passages = _load(con, target, _passages_sql(src, snapshot, limit),
+                             ["pmcid", "passage_index"], mode=mode)
         _log.info("passages: {:,} rows ({} mode)", passages, mode)
     return {"documents": documents, "passages": passages}
 
@@ -294,7 +306,7 @@ def ingest(
                 _log.info("loading single file {} (mode={}, schema={})", file, mode, schema)
                 raw = Path(file) if str(file).endswith(".parquet") else materialize_raw(con, file)
                 counts = curate(con, raw, schema=schema, snapshot=snapshot, limit=limit,
-                                mode=mode, passage_batches=passage_batches)
+                                mode=mode, passage_batches=passage_batches, run=r)
                 summary["documents"] += counts["documents"]
                 summary["passages"] += counts["passages"]
                 summary["ranges"].append(Path(file).name)
@@ -309,7 +321,7 @@ def ingest(
                     n_files = tar_to_ndjson(tar, ndjson)
                     raw = materialize_raw(con, ndjson)
                     counts = curate(con, raw, schema=schema, snapshot=snapshot, limit=limit,
-                                    mode=mode, passage_batches=passage_batches)
+                                    mode=mode, passage_batches=passage_batches, run=r)
                     summary["documents"] += counts["documents"]
                     summary["passages"] += counts["passages"]
                     summary["ranges"].append({"file": filename, "articles": n_files, **counts})

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -343,6 +343,32 @@ def test_pmc_curate(lake_settings: Settings, tmp_path):
         con.close()
 
 
+def test_pmc_ingest_attributes_snapshots(lake_settings: Settings):
+    """PMC append: each write is a self-describing snapshot (ADR-0007) bound by run_id."""
+    from cdsci.lake.sources import pmc
+
+    summary = pmc.ingest(
+        file=str(FIXTURES / "pmc_sample.ndjson"),
+        mode="append", passage_batches=2, snapshot="attr-test",
+        settings=lake_settings,
+    )
+    con = lake_connect(lake_settings, read_only=True)
+    try:
+        rows = con.execute(
+            "SELECT author, commit_message, commit_extra_info FROM lake.snapshots() "
+            "WHERE author IS NOT NULL ORDER BY snapshot_id"
+        ).fetchall()
+        # 1 documents write + 2 passage shards = 3 attributed snapshots.
+        ops = [json.loads(r[2])["op"] for r in rows]
+        assert ops == ["documents", "passages.shard1/2", "passages.shard2/2"]
+        # every snapshot self-attributes to this source and binds to the ops run.
+        assert all(r[0] == "cdsci:pmc" for r in rows)
+        assert all(json.loads(r[2])["run_id"] == summary["run_id"] for r in rows)
+        assert all(json.loads(r[2])["source"] == "pmc" for r in rows)
+    finally:
+        con.close()
+
+
 def test_census_geo_upsert_wkb(lake_settings: Settings):
     """ref.geo_state: geometry stored as WKB round-trips; tag-only change is idempotent."""
     con = lake_connect(lake_settings)

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -343,12 +343,17 @@ def test_pmc_curate(lake_settings: Settings, tmp_path):
         con.close()
 
 
-def test_pmc_ingest_attributes_snapshots(lake_settings: Settings):
+def test_pmc_ingest_attributes_snapshots(lake_settings: Settings, tmp_path: Path):
     """PMC append: each write is a self-describing snapshot (ADR-0007) bound by run_id."""
+    import shutil
+
     from cdsci.lake.sources import pmc
 
+    # stage into tmp so the bronze parquet lands there, not in the fixtures dir.
+    nd = tmp_path / "pmc_sample.ndjson"
+    shutil.copy(FIXTURES / "pmc_sample.ndjson", nd)
     summary = pmc.ingest(
-        file=str(FIXTURES / "pmc_sample.ndjson"),
+        file=str(nd),
         mode="append", passage_batches=2, snapshot="attr-test",
         settings=lake_settings,
     )


### PR DESCRIPTION
First in-place fix from ADR-0007: the catalog now answers "whose snapshot is this?" without the ledger or table-id spelunking.

- **`ops.Run.attribute(op)`** — wraps a load's write(s) in one transaction and stamps the snapshot via `set_commit_message`: `author='cdsci:<source>'`, a message, and JSON `commit_extra_info` `{writer, source, target, version, run_id, op}`.
- **`run_id` in `commit_extra_info`** binds the catalog snapshot to `lake_ops.run` by a stable key (ADR-0007: bind by run_id, not the ambiguous before/after id-range).
- **PMC `curate`** attributes each write (documents + each passage shard); unattributed when no run is passed (preserves test/library behavior). One snapshot per block, so per-block writes stay bounded (works with `--passage-batches`).

Verified end-to-end on the local backend with the ledger attached: 3 writes → 3 self-describing snapshots, each carrying the run_id.

## Test plan
- `uv run ruff check src/ tests/` — clean
- `uv run pytest -q` — passes (new `test_pmc_ingest_attributes_snapshots`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)