### PR TITLE
Self-describing snapshots for all upsert-based sources (ADR-0008)

### DIFF
--- a/docs/adr/0008-snapshot-attribution.md
+++ b/docs/adr/0008-snapshot-attribution.md
@@ -1,0 +1,79 @@
+# 0008. Self-describing snapshots: attribute every write in the catalog
+
+- Status: accepted
+- Date: 2026-06-24
+
+> Implements the first in-place fix from ADR-0007 (identify snapshots by source
+> without leaving the single shared catalog).
+
+## Context
+
+On the shared catalog, a snapshot's only intrinsic identity is its `changes` map
+(table-ids). ADR-0007 showed the cost: cdsci's 225 snapshots carried NULL
+`author`/`commit_message`/`commit_extra_info`, so "whose snapshot is this?" was
+answerable only by resolving table-id → schema through the Postgres metadata, or
+by the `lake_ops.run` snapshot-id **range** (ambiguous under concurrency). omicidx,
+by contrast, stamps each snapshot via DuckLake's `set_commit_message`
+(`author='prefect:ducklake-load'` + JSON `commit_extra_info`). Two attribution
+systems on one catalog; ours external and fuzzy.
+
+DuckLake exposes `CALL <catalog>.set_commit_message(author, message, extra_info)`,
+which annotates the snapshot produced by the **enclosing transaction's** commit. It
+is transaction-scoped, not a session setting, and `extra_info` is an opaque string
+(we put JSON in it). Verified on our version (DuckLake v1.0 / DuckDB 1.5.x).
+
+## Decision
+
+**Every cdsci write self-attributes the snapshot it produces.**
+
+1. **`ops.Run.attribute(op)`** — a context manager that opens a transaction, calls
+   `set_commit_message` with `author = "cdsci:<source>"`, a message, and a JSON
+   `commit_extra_info`:
+
+   ```json
+   {"writer":"cdsci","source":"<source>","target":"<catalog.schema>",
+    "version":"<snapshot_version>","run_id":"<uuid>","op":"<sub-step>"}
+   ```
+
+   runs the block, and commits (rolls back on error). One snapshot per block.
+
+2. **Auto-wired into `upsert`** — the shared MERGE chokepoint detects the active
+   run (an `ops` context-var set for the duration of `ops.run`) and wraps its write
+   in `run.attribute(<table>)`. So **every upsert-based source** (icite, reporter,
+   ctgov, scp, census_geo, europepmc, retractionwatch, reliance, openalex) is
+   attributed with no per-source change. PMC's append path (no upsert) calls
+   `attribute` explicitly per write (documents + each passage shard).
+
+3. **Re-entrant** — a nested `attribute` (PMC `curate` wrapping a `_load` that calls
+   the now-self-attributing `upsert`) joins the outer transaction; the outermost
+   owns the BEGIN/COMMIT and the message. No nested `BEGIN`, one snapshot.
+
+4. **`run_id` binds catalog ↔ ledger by a stable key**, not the `(before, after]`
+   id-range — the ADR-0007 fix for concurrency-ambiguous attribution.
+
+### Idempotency is preserved (the load-bearing property)
+
+A no-op MERGE inside an attributed transaction produces **no snapshot** — verified:
+`BEGIN; set_commit_message; <MERGE that changes nothing>; COMMIT` leaves the
+snapshot count unchanged, as does an empty transaction. So the no-op-is-free,
+time-travel-is-meaningful contract (ADR-0003) holds unchanged; only a real change
+creates a snapshot, and that snapshot now carries its attribution. Outside an
+`ops.run` (e.g. a direct test/util call) `upsert` runs unattributed.
+
+## Consequences
+
+- The catalog answers "whose snapshot, which run, which step?" on its own — no
+  ledger join, no table-id resolution. Audit/reclamation can filter by `author` /
+  `commit_extra_info->>'source'` / `run_id` / `op`.
+- First loads emit **one** attributed snapshot per table instead of two
+  (`CREATE TABLE` + `MERGE` now share the attribute transaction).
+- The JSON shape is **reconciled in spirit with omicidx's** (`entity`/`source`/
+  `operation`/`prefect_run_id`); a future shared key set lets one query attribute
+  any publisher's snapshot. `commit_extra_info` is unvalidated text by DuckLake, so
+  the convention is enforced only by us.
+- **Not yet attributed:** maintenance/DDL snapshots (drop/expire in
+  `maintenance_cli`) and any ad-hoc SQL. Worth attributing those next so no
+  snapshot is anonymous.
+- Attribution depends on DuckLake's transaction-scoped `set_commit_message`; the
+  explicit-transaction wrapper is therefore mandatory and bounds each attributed
+  write to one transaction (keep per-block writes bounded — see PMC shards).

--- a/src/cdsci/lake/connect.py
+++ b/src/cdsci/lake/connect.py
@@ -14,6 +14,7 @@ lock-in risk of a young format low.
 from __future__ import annotations
 
 import os
+from contextlib import nullcontext
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -242,29 +243,42 @@ def upsert(
     would mark every row "changed" each load and force a full rewrite; with it,
     only rows whose *real* data moved are rewritten, and the stamp then records
     the snapshot in which a row last actually changed.
+
+    When called inside an :func:`cdsci.lake.ops.run` block, the MERGE is wrapped
+    in that run's :meth:`~cdsci.lake.ops.Run.attribute` so the snapshot it produces
+    is self-describing (author/source/run_id, ADR-0009). An idempotent MERGE makes
+    no snapshot even when wrapped, so the no-op-is-free contract holds; outside a
+    run (e.g. a direct test call) the write is unattributed.
     """
+    from . import ops  # local import avoids a connect<->ops circular dependency
+
     parts = target.split(".")
     if len(parts) != 3:
         raise ValueError(f"target must be catalog.schema.table, got {target!r}")
-    catalog, schema, _ = parts
+    catalog, schema, table = parts
     keys = [key] if isinstance(key, str) else list(key)
     ignore = set(exclude_change_cols or [])
 
-    con.execute(f"CREATE SCHEMA IF NOT EXISTS {catalog}.{schema};")
-    con.execute(f"CREATE OR REPLACE TEMP TABLE _cri_stage AS {source_sql};")
-    con.execute(f"CREATE TABLE IF NOT EXISTS {target} AS SELECT * FROM _cri_stage WHERE false;")
+    run = ops.active_run()
+    attribution = run.attribute(table) if run is not None else nullcontext()
+    with attribution:
+        con.execute(f"CREATE SCHEMA IF NOT EXISTS {catalog}.{schema};")
+        con.execute(f"CREATE OR REPLACE TEMP TABLE _cri_stage AS {source_sql};")
+        con.execute(
+            f"CREATE TABLE IF NOT EXISTS {target} AS SELECT * FROM _cri_stage WHERE false;"
+        )
 
-    cols = [c[0] for c in con.execute("DESCRIBE _cri_stage").fetchall()]
-    compare = [c for c in cols if c not in keys and c not in ignore]
-    on = " AND ".join(f"t.{k} = s.{k}" for k in keys)
-    matched = ""
-    if compare:
-        changed = " OR ".join(f"t.{c} IS DISTINCT FROM s.{c}" for c in compare)
-        matched = f"WHEN MATCHED AND ({changed}) THEN UPDATE SET * "
-    con.execute(
-        f"MERGE INTO {target} AS t USING _cri_stage AS s ON {on} "
-        f"{matched}WHEN NOT MATCHED THEN INSERT *;"
-    )
+        cols = [c[0] for c in con.execute("DESCRIBE _cri_stage").fetchall()]
+        compare = [c for c in cols if c not in keys and c not in ignore]
+        on = " AND ".join(f"t.{k} = s.{k}" for k in keys)
+        matched = ""
+        if compare:
+            changed = " OR ".join(f"t.{c} IS DISTINCT FROM s.{c}" for c in compare)
+            matched = f"WHEN MATCHED AND ({changed}) THEN UPDATE SET * "
+        con.execute(
+            f"MERGE INTO {target} AS t USING _cri_stage AS s ON {on} "
+            f"{matched}WHEN NOT MATCHED THEN INSERT *;"
+        )
     return con.execute(f"SELECT count(*) FROM {target}").fetchone()[0]
 
 

--- a/src/cdsci/lake/ops.py
+++ b/src/cdsci/lake/ops.py
@@ -28,6 +28,7 @@ import socket
 import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import Any
 
@@ -38,6 +39,16 @@ from .log import logger
 
 OPS = "ops"  # the ATTACH alias for the ledger database
 OPS_SCHEMA = "lake_ops"
+
+# The run currently executing on this context, so :func:`cdsci.lake.connect.upsert`
+# can self-attribute its snapshot (ADR-0009) without every curate threading the
+# Run through. Set for the duration of a :func:`run` block.
+_ACTIVE_RUN: ContextVar[Run | None] = ContextVar("active_run", default=None)
+
+
+def active_run() -> Run | None:
+    """The :class:`Run` for the enclosing :func:`run` block, or None outside one."""
+    return _ACTIVE_RUN.get()
 
 
 def _t(table: str) -> str:
@@ -155,6 +166,7 @@ class Run:
     rows: int | None = None
     snapshot_after: int | None = None
     status: str | None = None
+    _txn_depth: int = 0  # re-entrancy guard for nested attribute() blocks
 
     @property
     def changed(self) -> bool:
@@ -188,7 +200,20 @@ class Run:
         Each block is its own transaction, so do **not** wrap an unbounded write in
         one block expecting it to stay small — keep the per-block write bounded
         (the PMC passages shards are sized for exactly this).
+
+        **Re-entrant:** a nested ``attribute`` (e.g. PMC ``curate`` wrapping a
+        ``_load`` that itself calls the now-self-attributing :func:`upsert`) joins
+        the outer transaction — the outermost block owns the BEGIN/COMMIT and the
+        commit message; inner blocks just run. So one snapshot, no nested BEGIN.
         """
+        if self._txn_depth > 0:
+            self._txn_depth += 1
+            try:
+                yield
+            finally:
+                self._txn_depth -= 1
+            return
+
         extra = json.dumps({
             "writer": "cdsci", "source": self.source, "target": self.target,
             "version": self.version, "run_id": self.run_id, "op": op,
@@ -198,6 +223,7 @@ class Run:
             f"CALL {LAKE}.set_commit_message(?, ?, extra_info => ?);",
             [f"cdsci:{self.source}", message or f"{self.source}: {op}", extra],
         )
+        self._txn_depth = 1
         try:
             yield
         except BaseException:
@@ -205,6 +231,8 @@ class Run:
             raise
         else:
             self.con.execute("COMMIT;")
+        finally:
+            self._txn_depth = 0
 
 
 def _max_snapshot(con: duckdb.DuckDBPyConnection) -> int | None:
@@ -247,34 +275,38 @@ def run(
         target, version, before, rid,
     )
     r = Run(con, rid, source, target, version, before)
+    token = _ACTIVE_RUN.set(r)
     try:
-        yield r
-    except Exception as exc:  # noqa: BLE001 — record then re-raise
-        after = _max_snapshot(con)
-        con.execute(
-            f"UPDATE {_t('run')} SET status='error', snapshot_after=?, rows_after=?, "
-            "finished_at=current_timestamp, error=? WHERE run_id=?",
-            [after, r.rows, str(exc)[:2000], rid],
-        )
-        r.snapshot_after, r.status = after, "error"
-        bound.error(
-            "ERROR after {} rows (snapshot {}→{}, run_id={}): {}",
-            r.rows, before, after, rid, exc,
-        )
-        raise
-    else:
-        after = _max_snapshot(con)
-        status = "idempotent" if after == before else "success"
-        con.execute(
-            f"UPDATE {_t('run')} SET status=?, snapshot_after=?, rows_after=?, "
-            "finished_at=current_timestamp WHERE run_id=?",
-            [status, after, r.rows, rid],
-        )
-        r.snapshot_after, r.status = after, status
-        bound.success(
-            "{} → {} (rows={}, snapshot {}→{}, run_id={})",
-            status, target, r.rows, before, after, rid,
-        )
+        try:
+            yield r
+        except Exception as exc:  # noqa: BLE001 — record then re-raise
+            after = _max_snapshot(con)
+            con.execute(
+                f"UPDATE {_t('run')} SET status='error', snapshot_after=?, rows_after=?, "
+                "finished_at=current_timestamp, error=? WHERE run_id=?",
+                [after, r.rows, str(exc)[:2000], rid],
+            )
+            r.snapshot_after, r.status = after, "error"
+            bound.error(
+                "ERROR after {} rows (snapshot {}→{}, run_id={}): {}",
+                r.rows, before, after, rid, exc,
+            )
+            raise
+        else:
+            after = _max_snapshot(con)
+            status = "idempotent" if after == before else "success"
+            con.execute(
+                f"UPDATE {_t('run')} SET status=?, snapshot_after=?, rows_after=?, "
+                "finished_at=current_timestamp WHERE run_id=?",
+                [status, after, r.rows, rid],
+            )
+            r.snapshot_after, r.status = after, status
+            bound.success(
+                "{} → {} (rows={}, snapshot {}→{}, run_id={})",
+                status, target, r.rows, before, after, rid,
+            )
+    finally:
+        _ACTIVE_RUN.reset(token)
 
 
 def last_run(

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -7,6 +7,7 @@ registry, the :func:`ops.run` context manager (success / idempotent / error),
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -76,6 +77,16 @@ def test_run_records_success_then_idempotent(lake_settings: Settings):
             "changed": True, "snapshot": r.snapshot_after, "run_id": r.run_id,
             "status": "success",
         }
+
+        # The snapshot upsert produced is self-describing (ADR-0009): authored by
+        # the source, op = the table name, and bound back to this run_id.
+        author, extra = con.execute(
+            "SELECT author, commit_extra_info FROM lake.snapshots() WHERE snapshot_id = ?",
+            [r.snapshot_after],
+        ).fetchone()
+        assert author == "cdsci:icite"
+        meta = json.loads(extra)
+        assert meta["source"] == "icite" and meta["op"] == "t" and meta["run_id"] == r.run_id
 
         with ops.run(con, source="icite", target="lake.main.t", version="2026-06") as r2:
             r2.rows = upsert(con, "lake.main.t", src, key="id")  # same data


### PR DESCRIPTION
Implements the snapshot-attribution fix from ADR-0007 across **all** sources (not just PMC), so the shared catalog answers "whose snapshot is this?" on its own.

## What
- **`ops.Run.attribute(op)`** stamps the snapshot a write produces via DuckLake `set_commit_message`: `author='cdsci:<source>'`, a message, and JSON `commit_extra_info` `{writer, source, target, version, run_id, op}`. Now **re-entrant** (nested blocks join one transaction).
- **Auto-wired into `upsert`** via an active-run context var set for the duration of `ops.run` — so every upsert-based source (icite, reporter, ctgov, scp, census_geo, europepmc, retractionwatch, reliance, openalex) is attributed with **no per-source change**. PMC's append path already attributes explicitly.
- **`run_id`** in `commit_extra_info` binds catalog ↔ `lake_ops.run` by a stable key (ADR-0007: bind by run_id, not the ambiguous id-range).

## Idempotency preserved (verified)
A no-op MERGE inside the attributed transaction produces **no snapshot**, so ADR-0003's "no-op is free / time-travel is meaningful" contract is unchanged. Only real changes create a snapshot — now self-describing.

## ADR
`docs/adr/0008-snapshot-attribution.md` records the convention + the idempotency property.

## Test plan
- `uv run ruff check src/ tests/` — clean
- `uv run pytest -q` — 26 passed, 3 skipped (extended `test_run_records_success_then_idempotent` to assert the snapshot is authored `cdsci:icite`, op=table, bound to run_id)

🤖 Generated with [Claude Code](https://claude.com/claude-code)