### PR TITLE
Wire loguru logging into every source (ADR-0009)

### DIFF
--- a/docs/adr/0009-structured-logging.md
+++ b/docs/adr/0009-structured-logging.md
@@ -1,0 +1,51 @@
+# 0009. Structured logging with loguru across the substrate and ingestors
+
+- Status: accepted
+- Date: 2026-06-24
+
+## Context
+
+Ingestors were observability-thin: a `print()` here, `typer.echo()` for the final
+summary, nothing in between. A multi-hour bulk load (PMC) that failed left a bare
+traceback with no trail of which range/step it reached, and there was no consistent,
+leveled, timestamped output. We need one logging surface that is **on for the
+ingest CLIs** but **silent for the read-client library** — a consumer who
+`pip install cdsci-lake` and calls `lake_connect(read_only=True)` should get no log
+noise unless they ask for it.
+
+## Decision
+
+**loguru, behind a shared `cdsci.lake.log` module.**
+
+- `configure(level)` installs a single stderr sink (level from `$CDSCI_LOG_LEVEL`,
+  default `INFO`) with a timestamp + level + `ctx` + message format. `logger` is the
+  shared instance. `loguru` is a base dependency.
+- **Library code never configures at import.** Only the CLIs call `configure()` —
+  each source's `__main__.py` has a typer `@app.callback()` with a `--log-level`
+  option that calls it. So importing the package as a read client stays quiet; an
+  ingest invocation is fully logged.
+- Modules bind a context: `_log = logger.bind(ctx="<source>")`, so every line is
+  tagged with where it came from (`pmc`, `download`, `run:icite`, …).
+- **Three layers of coverage, mostly shared so sources don't each reinvent it:**
+  1. `ops.run` logs the run lifecycle — start / success / idempotent / error with
+     rows and snapshot deltas — for **every** source automatically.
+  2. The shared `download.py` logs fetch start/done (+ size) and zip extraction, so
+     every source that downloads gets fetch logging for free.
+  3. Per-source ingest adds milestone lines (per-table curate counts, per-batch /
+     per-database / per-domain loop progress). PMC logs per-range stream/curate.
+- Log calls use loguru brace formatting (`_log.info("x {} y {}", a, b)`), never
+  f-strings, so message rendering stays lazy and structured. `print()` in the
+  OpenAlex ingest was replaced with `_log.info`.
+
+## Consequences
+
+- Every `python -m cdsci.lake.sources.<source> …` emits a consistent, leveled,
+  timestamped trail; a failure is preceded by the step it reached, and
+  `--log-level DEBUG` turns up detail (e.g. download resume/range restarts).
+- The read client stays silent by default — no sink is installed until a CLI (or a
+  caller) invokes `configure()`.
+- New sources inherit run + fetch logging by using `ops.run` and `download.py`; the
+  only per-source work is binding `ctx` and a few milestone lines.
+- Conventions to keep: `configure()` belongs in the CLI callback only; bind `ctx`
+  per module; brace-format log args; reserve `INFO` for milestones and `DEBUG` for
+  per-item/loop detail so a normal run stays readable.

--- a/src/cdsci/lake/download.py
+++ b/src/cdsci/lake/download.py
@@ -14,7 +14,10 @@ from pathlib import Path
 import httpx
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
+from .log import logger
+
 _TIMEOUT = httpx.Timeout(60.0, read=300.0)
+_log = logger.bind(ctx="download")
 
 
 @retry(
@@ -59,10 +62,15 @@ def download(
     exists it is returned untouched — re-running an ingest does not re-download.
     """
     if dest.exists():
+        _log.debug("cached, skipping download: {}", dest.name)
         return dest
     dest.parent.mkdir(parents=True, exist_ok=True)
     part = dest.with_suffix(dest.suffix + ".part")
     existing = part.stat().st_size if (resume and part.exists()) else 0
+    _log.info(
+        "downloading {} → {}{}",
+        url, dest.name, f" (resuming from {existing / 1e6:.1f} MB)" if existing else "",
+    )
 
     @retry(
         retry=retry_if_exception_type(httpx.HTTPError),
@@ -89,10 +97,12 @@ def download(
     try:
         _fetch(existing)
     except _RangeIgnored:
+        _log.debug("server ignored Range for {} — restarting from 0", dest.name)
         part.unlink(missing_ok=True)
         _fetch(0)
 
     part.rename(dest)
+    _log.info("downloaded {} ({:.1f} MB)", dest.name, dest.stat().st_size / 1e6)
     return dest
 
 
@@ -113,6 +123,7 @@ def unzip(archive: Path, dest_dir: Path) -> list[Path]:
                     while chunk := src.read(1 << 20):
                         dst.write(chunk)
             out.append(target)
+    _log.info("extracted {} file(s) from {} → {}", len(out), archive.name, dest_dir)
     return out
 
 

--- a/src/cdsci/lake/sources/census_geo/__main__.py
+++ b/src/cdsci/lake/sources/census_geo/__main__.py
@@ -4,12 +4,18 @@ from __future__ import annotations
 
 import typer
 
+from ...log import configure
 from .ingest import LAYERS, ingest
 
 app = typer.Typer(
     help="Load US Census cartographic boundaries into ref.geo_state / ref.geo_county.",
     add_completion=False,
 )
+
+
+@app.callback()
+def _main(log_level: str = typer.Option("INFO", "--log-level", help="loguru level.")) -> None:
+    configure(log_level)
 
 
 @app.command("layers")

--- a/src/cdsci/lake/sources/census_geo/ingest.py
+++ b/src/cdsci/lake/sources/census_geo/ingest.py
@@ -18,6 +18,9 @@ from ... import ops
 from ...config import Settings, get_settings
 from ...connect import LAKE, lake_connect, raw_dir, upsert
 from ...download import download, unzip
+from ...log import logger
+
+_log = logger.bind(ctx="census_geo")
 
 
 @dataclass(frozen=True)
@@ -120,6 +123,7 @@ def ingest(
             for layer in layers or list(LAYERS):
                 shp = download_layer(layer, year, s)
                 counts[layer] = curate(con, layer, shp, schema=schema, year=year)
+                _log.info("{} <- {:,} rows", layer, counts[layer])
             r.rows = sum(counts.values())
     finally:
         con.close()

--- a/src/cdsci/lake/sources/ctgov/__main__.py
+++ b/src/cdsci/lake/sources/ctgov/__main__.py
@@ -6,12 +6,18 @@ import typer
 
 from ...config import get_settings
 from ...download import get_json
+from ...log import configure
 from .ingest import ingest
 
 app = typer.Typer(
     help="Ingest ClinicalTrials.gov studies (full JSON) into lake.ctgov.{studies,references}.",
     add_completion=False,
 )
+
+
+@app.callback()
+def _main(log_level: str = typer.Option("INFO", "--log-level", help="loguru level.")) -> None:
+    configure(log_level)
 
 
 @app.command("count")

--- a/src/cdsci/lake/sources/europepmc/__main__.py
+++ b/src/cdsci/lake/sources/europepmc/__main__.py
@@ -4,12 +4,18 @@ from __future__ import annotations
 
 import typer
 
+from ...log import configure
 from .ingest import ingest, list_databases
 
 app = typer.Typer(
     help="Ingest Europe PMC text-mined annotations into lake.europepmc.annotations.",
     add_completion=False,
 )
+
+
+@app.callback()
+def _main(log_level: str = typer.Option("INFO", "--log-level", help="loguru level.")) -> None:
+    configure(log_level)
 
 
 @app.command("databases")

--- a/src/cdsci/lake/sources/europepmc/ingest.py
+++ b/src/cdsci/lake/sources/europepmc/ingest.py
@@ -33,10 +33,12 @@ from ... import ops
 from ...config import Settings, get_settings
 from ...connect import LAKE, csv_source, lake_connect, raw_dir, upsert
 from ...download import download
+from ...log import logger
 
 _TABLE = "europepmc.annotations"  # lake table (schema.table)
 _RAW = "europepmc"  # raw-download subdir name
 _TIMEOUT = httpx.Timeout(60.0, read=120.0)
+_log = logger.bind(ctx="europepmc")
 
 
 def _sql_str(value: str) -> str:
@@ -153,6 +155,7 @@ def ingest(
             for db, path in plan:
                 path = path or download_database(db, version, s)
                 counts[db] = curate(con, db, path, version, target=target, limit=limit)
+                _log.info("{} <- {:,} rows", db, counts[db])
             r.rows = sum(counts.values())
     finally:
         con.close()

--- a/src/cdsci/lake/sources/icite/__main__.py
+++ b/src/cdsci/lake/sources/icite/__main__.py
@@ -4,12 +4,18 @@ from __future__ import annotations
 
 import typer
 
+from ...log import configure
 from .ingest import ingest, resolve_latest
 
 app = typer.Typer(
     help="Ingest the monthly iCite bulk snapshot into lake.icite.metadata.",
     add_completion=False,
 )
+
+
+@app.callback()
+def _main(log_level: str = typer.Option("INFO", "--log-level", help="loguru level.")) -> None:
+    configure(log_level)
 
 
 @app.command("latest")

--- a/src/cdsci/lake/sources/openalex/__main__.py
+++ b/src/cdsci/lake/sources/openalex/__main__.py
@@ -15,12 +15,18 @@ import typer
 from ... import ops
 from ...config import get_settings
 from ...connect import LAKE, lake_connect
+from ...log import configure
 from .ingest import ENTITIES, ingest_entity, ingest_works, part_urls
 
 app = typer.Typer(
     help="Load the OpenAlex snapshot (works + reference entities) into the lake.",
     add_completion=False,
 )
+
+
+@app.callback()
+def _main(log_level: str = typer.Option("INFO", "--log-level", help="loguru level.")) -> None:
+    configure(log_level)
 
 
 @app.command("parts")

--- a/src/cdsci/lake/sources/openalex/ingest.py
+++ b/src/cdsci/lake/sources/openalex/ingest.py
@@ -34,6 +34,9 @@ import duckdb
 from ... import ops
 from ...config import Settings, get_settings
 from ...connect import LAKE, lake_connect, upsert
+from ...log import logger
+
+_log = logger.bind(ctx="openalex")
 
 
 def _today_version() -> str:
@@ -434,9 +437,9 @@ def ingest_works(
                     con, chunk, schema=schema, version=version, mode=mode,
                     domains=s.openalex_domains, max_obj=s.openalex_max_object_bytes,
                 )
-                print(f"  works batch {n}/{len(batches)} ({len(chunk)} parts): "
-                      f"works={totals['works']:,} refs={totals['references']:,} "
-                      f"authorships={totals['authorships']:,}")
+                _log.info("works batch {}/{} ({} parts): works={:,} refs={:,} authorships={:,}",
+                          n, len(batches), len(chunk), totals["works"],
+                          totals["references"], totals["authorships"])
             r.rows = totals["works"]
     finally:
         if owns:
@@ -497,7 +500,7 @@ def run(
                 entity, schema=schema, version=version, mode=mode,
                 max_files=max_files, settings=s, con=con,
             )
-            print(f"  {entity}: {counts[entity]:,}")
+            _log.info("entity {}: {:,} rows", entity, counts[entity])
         if works:
             w = ingest_works(
                 schema=schema, version=version, mode=mode,

--- a/src/cdsci/lake/sources/reliance/__main__.py
+++ b/src/cdsci/lake/sources/reliance/__main__.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import typer
 
+from ...log import configure
 from .ingest import DATASETS, ingest
 
 app = typer.Typer(
@@ -17,8 +18,9 @@ app = typer.Typer(
 
 
 @app.callback()
-def main() -> None:
+def main(log_level: str = typer.Option("INFO", "--log-level", help="loguru level.")) -> None:
     """Reliance on Science ingestor (keeps the ``run`` subcommand explicit)."""
+    configure(log_level)
 
 
 @app.command("run")

--- a/src/cdsci/lake/sources/reliance/ingest.py
+++ b/src/cdsci/lake/sources/reliance/ingest.py
@@ -29,8 +29,10 @@ from ... import ops
 from ...config import Settings, get_settings
 from ...connect import LAKE, csv_source, lake_connect, raw_dir, upsert
 from ...download import download
+from ...log import logger
 
 _RAW = "reliance"  # raw-download subdir name
+_log = logger.bind(ctx="reliance")
 
 
 @dataclass(frozen=True)
@@ -147,6 +149,7 @@ def ingest(
             for name in names:
                 path = Path(file) if file else download_dataset(name, version, s)
                 counts[name] = curate(con, name, path, version, schema=schema, limit=limit)
+                _log.info("{} <- {:,} rows", name, counts[name])
             r.rows = sum(counts.values())
     finally:
         con.close()

--- a/src/cdsci/lake/sources/reporter/__main__.py
+++ b/src/cdsci/lake/sources/reporter/__main__.py
@@ -4,12 +4,18 @@ from __future__ import annotations
 
 import typer
 
+from ...log import configure
 from .ingest import GROUPS, available_years, ingest
 
 app = typer.Typer(
     help="Ingest NIH RePORTER ExPORTER groups (projects/abstracts/publications/publink).",
     add_completion=False,
 )
+
+
+@app.callback()
+def _main(log_level: str = typer.Option("INFO", "--log-level", help="loguru level.")) -> None:
+    configure(log_level)
 
 
 @app.command("groups")

--- a/src/cdsci/lake/sources/retractionwatch/__main__.py
+++ b/src/cdsci/lake/sources/retractionwatch/__main__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import typer
 
+from ...log import configure
 from .ingest import ingest
 
 app = typer.Typer(
@@ -13,8 +14,9 @@ app = typer.Typer(
 
 
 @app.callback()
-def main() -> None:
+def main(log_level: str = typer.Option("INFO", "--log-level", help="loguru level.")) -> None:
     """Retraction Watch ingestor (keeps the ``run`` subcommand explicit)."""
+    configure(log_level)
 
 
 @app.command("run")

--- a/src/cdsci/lake/sources/scp/__main__.py
+++ b/src/cdsci/lake/sources/scp/__main__.py
@@ -4,12 +4,18 @@ from __future__ import annotations
 
 import typer
 
+from ...log import configure
 from .ingest import DOMAINS, ingest, resolve_latest
 
 app = typer.Typer(
     help="Ingest State Cancer Profiles (GitHub releases) into lake.scp.{incidence,mortality,risk,demographics}.",
     add_completion=False,
 )
+
+
+@app.callback()
+def _main(log_level: str = typer.Option("INFO", "--log-level", help="loguru level.")) -> None:
+    configure(log_level)
 
 
 @app.command("latest")

--- a/src/cdsci/lake/sources/scp/ingest.py
+++ b/src/cdsci/lake/sources/scp/ingest.py
@@ -47,8 +47,10 @@ from ... import ops
 from ...config import Settings, get_settings
 from ...connect import LAKE, csv_source, lake_connect, raw_dir, upsert
 from ...download import download, get_json
+from ...log import logger
 
 _RAW = "scp"  # raw-download subdir name
+_log = logger.bind(ctx="scp")
 
 
 def _sql_str(value: str) -> str:
@@ -324,6 +326,7 @@ def ingest(
                     raise ValueError(f"Unknown domain {domain!r}; choose from {sorted(DOMAINS)}")
                 target = f"{LAKE}.{schema}.{DOMAINS[domain].table}"
                 counts[domain] = curate(con, domain, path, tag, target=target, limit=limit)
+                _log.info("{} <- {:,} rows", domain, counts[domain])
             r.rows = sum(counts.values())
     finally:
         con.close()


### PR DESCRIPTION
Second of the two PRs: extends loguru logging (already in pmc/ops/maintenance) to **all** sources.

## What
- **Every source CLI** gains a typer `@app.callback()` with `--log-level` that calls `log.configure()`, so `python -m cdsci.lake.sources.<x>` is logged while the read client stays silent (configure is CLI-only).
- **Shared `download.py`** logs fetch start/done (+ size) and zip extraction → every downloading source gets fetch logging for free.
- **Per-source ingest milestones:** openalex (batch/entity progress; its two `print()` calls replaced with `logger`) and the loop sources scp / europepmc / reliance / census_geo (per-table curate counts). With the `ops.run` lifecycle (start/success/idempotent/error) this covers every source.

## ADR
`docs/adr/0009-structured-logging.md` — shared `cdsci.lake.log`, `configure()` in the CLI callback only, `ctx`-bound loggers, brace formatting, read-client-silent.

## Test plan
- `uv run ruff check src/ tests/` — clean
- `uv run pytest -q` — 26 passed, 3 skipped
- Smoke: all 9 source CLIs load with the `--log-level` callback (`--help` OK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)