### PR TITLE
Scaffold the MeSH ingestor (ADR-0010, Phase 1a)

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -73,6 +73,15 @@ cdsci-lake` and `lake_connect(read_only=True)`.
   `topics`. Branch `openalex-source` (off `census-geo`). See ADR-0005 +
   `docs/design/openalex.md`. To load: `python -m cdsci.lake.sources.openalex entities`
   then `... works --mode append` (full server run).
+- **MeSH importer** (`mesh`) — **scaffolded, NOT yet loaded.** NLM controlled
+  vocabulary + tree hierarchy from the annual descriptor + qualifier XML, stdlib
+  `iterparse` → bronze Parquet → five MERGE-upsert tables: `mesh.descriptor`,
+  `mesh.tree` (exploded `(descriptor_ui, tree_number)` + `parent_tree_number`;
+  polyhierarchy native — `tree_number LIKE 'C04%'` rolls up "everything under
+  Neoplasms"), `mesh.qualifier`, `mesh.descriptor_qualifier`, `mesh.entry_term`.
+  Complementary to `openalex.topics`. The literature edge (`mesh.article_heading`
+  from `omicidx.pubmed_article.mesh_terms`, which carries the `D…`/`Q…` UIs) is
+  Phase 1b. See ADR-0010. To load: `python -m cdsci.lake.sources.mesh run`.
 - **MERGE-upsert** (`cdsci.lake.upsert`, ADR-0003) — keyed, change-detecting (updates
   only on real diffs), idempotent (no-op re-run adds no snapshot) → meaningful
   time-travel. Per-load stamps (`snapshot_version`) are excluded from change-detection

--- a/src/cdsci/lake/config.py
+++ b/src/cdsci/lake/config.py
@@ -132,6 +132,12 @@ class Settings(BaseSettings):
     retractionwatch_url: str = (
         "https://gitlab.com/crossref/retraction-watch-data/-/raw/main/retraction_watch.csv"
     )
+    # NLM MeSH (Medical Subject Headings) — descriptor + qualifier XML, released
+    # annually (ADR-0010). ``desc{year}.gz`` is the controlled vocabulary + tree
+    # hierarchy; ``qual{year}.xml`` the ~80 subheadings. Supplementary Concept
+    # Records (``supp``) are deferred. ``mesh_year`` selects the annual edition.
+    mesh_xml_base: str = "https://nlmpubs.nlm.nih.gov/projects/mesh/MESH_FILES/xmlmesh/"
+    mesh_year: int = 2026
     # Reliance on Science (Marx) — patent↔paper links, keyed by OpenAlex Work ID.
     # **CC BY-NC 4.0**: internal non-commercial use only, NOT for redistribution;
     # the license is carried forward in the lake_ops source registry. A pinned

--- a/src/cdsci/lake/ops.py
+++ b/src/cdsci/lake/ops.py
@@ -89,6 +89,8 @@ SOURCES: tuple[Source, ...] = (
            "annual", "census-cartographic", "us-public-domain"),
     Source("europepmc", "europepmc", "Europe PMC text-mined annotations (PMCID↔term)",
            "monthly", "europepmc-bulk", "europepmc-terms"),
+    Source("mesh", "mesh", "NLM MeSH controlled vocabulary: descriptors + tree + qualifiers",
+           "annual", "nlm-xml", "us-public-domain"),
     Source("retractionwatch", "retractionwatch", "Retraction Watch retraction/correction notices",
            "weekday-daily", "crossref-gitlab-csv", "cc0", watermark_strategy="full"),
     # CC BY-NC 4.0: internal non-commercial use only, do NOT redistribute. The

--- a/src/cdsci/lake/sources/mesh/__init__.py
+++ b/src/cdsci/lake/sources/mesh/__init__.py
@@ -1,0 +1,34 @@
+"""NLM MeSH — the controlled vocabulary + tree hierarchy, from the annual XML.
+
+Complementary to ``openalex.topics`` (algorithmic, on works): MeSH is NLM-curated
+and human-assigned to PubMed, and its **tree numbers are the hierarchy** (ADR-0010).
+Five tables (Phase 1a — the vocabulary):
+
+* ``mesh.descriptor`` — one row per ``descriptor_ui`` (``name``, ``scope_note``).
+* ``mesh.tree`` — exploded ``(descriptor_ui, tree_number)`` + ``parent_tree_number``;
+  a descriptor has 0..N tree numbers (polyhierarchy). "Everything under Neoplasms"
+  is ``tree_number LIKE 'C04%'``; deep traversal via a recursive CTE.
+* ``mesh.qualifier`` — the ~80 subheadings, key ``qualifier_ui``.
+* ``mesh.descriptor_qualifier`` — allowable-qualifier bridge ``(descriptor_ui,
+  qualifier_ui)``.
+* ``mesh.entry_term`` — synonyms ``(descriptor_ui, term, is_preferred)``.
+
+The literature edge (``mesh.article_heading`` exploded from ``omicidx.pubmed_article
+.mesh_terms``, which carries the ``D…``/``Q…`` UIs) is Phase 1b — not built here.
+"""
+
+from .ingest import (
+    curate,
+    descriptors_to_ndjson,
+    ingest,
+    materialize_raw,
+    qualifiers_to_ndjson,
+)
+
+__all__ = [
+    "curate",
+    "descriptors_to_ndjson",
+    "ingest",
+    "materialize_raw",
+    "qualifiers_to_ndjson",
+]

--- a/src/cdsci/lake/sources/mesh/__main__.py
+++ b/src/cdsci/lake/sources/mesh/__main__.py
@@ -1,0 +1,47 @@
+"""CLI: ``python -m cdsci.lake.sources.mesh`` — load NLM MeSH into ``mesh.*``."""
+
+from __future__ import annotations
+
+import typer
+
+from ...log import configure
+from .ingest import ingest
+
+app = typer.Typer(
+    help="Ingest NLM MeSH descriptors + tree hierarchy + qualifiers into lake.mesh.*.",
+    add_completion=False,
+)
+
+
+@app.callback()
+def _main(log_level: str = typer.Option("INFO", "--log-level", help="loguru level.")) -> None:
+    configure(log_level)
+
+
+@app.command("run")
+def run(
+    year: int | None = typer.Option(
+        None, "--year", help="MeSH edition year (default: config mesh_year)."
+    ),
+    descriptor_file: str | None = typer.Option(
+        None, "--descriptor-file", help="Local desc XML/.gz/.parquet instead of downloading."
+    ),
+    qualifier_file: str | None = typer.Option(
+        None, "--qualifier-file", help="Local qual XML/.parquet instead of downloading."
+    ),
+    schema: str = typer.Option("mesh", "--schema", help="Target lake schema."),
+    limit: int | None = typer.Option(None, "--limit", help="Cap descriptors (smoke test)."),
+) -> None:
+    """Download (unless --*-file) and MERGE-upsert the five MeSH tables."""
+    s = ingest(
+        year=year, descriptor_file=descriptor_file, qualifier_file=qualifier_file,
+        schema=schema, limit=limit,
+    )
+    delta = "changed" if s["changed"] else "no change (idempotent)"
+    counts = {k: s[k] for k in
+              ("descriptor", "tree", "qualifier", "descriptor_qualifier", "entry_term")}
+    typer.echo(f"{s['schema']} <- {s['rows']:,} rows — {delta}: {counts}")
+
+
+if __name__ == "__main__":
+    app()

--- a/src/cdsci/lake/sources/mesh/ingest.py
+++ b/src/cdsci/lake/sources/mesh/ingest.py
@@ -1,0 +1,287 @@
+"""Ingest NLM MeSH (descriptors + tree hierarchy + qualifiers) into ``mesh.*``.
+
+Medallion flow (ADR-0012, mirrors ctgov), driven from the annual descriptor +
+qualifier **XML** (no maintained Python MeSH library exists, and the SPARQL
+endpoint caps at 1000 rows / the RDF dump is ~2 GB — see ADR-0010):
+
+1. **download** ``desc{year}.gz`` + ``qual{year}.xml`` to the raw layer.
+2. **stream → NDJSON** — ``xml.etree.iterparse`` over each record (stdlib, no new
+   dependency), one compact structured JSON object per descriptor / qualifier.
+3. **materialize** a bronze Parquet from the NDJSON (read_json infers the nested
+   ``tree_numbers`` / ``qualifiers`` / ``entry_terms`` shapes).
+4. **curate** five silver tables, all MERGE-upsert (idempotent, attributed):
+   * ``mesh.descriptor`` — one row per ``descriptor_ui`` (name + scope note).
+   * ``mesh.tree`` — the **hierarchy**, exploded ``(descriptor_ui, tree_number)``
+     with a derived ``parent_tree_number`` (polyhierarchy is native — a descriptor
+     has 0..N tree numbers).
+   * ``mesh.qualifier`` — the ~80 subheadings.
+   * ``mesh.descriptor_qualifier`` — allowable-qualifier bridge.
+   * ``mesh.entry_term`` — synonyms (``is_preferred`` flags the descriptor name).
+
+The literature edge (``mesh.article_heading`` from ``omicidx.pubmed_article``) is
+Phase 1b — not built here. Supplementary Concept Records (``supp``) are deferred.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import duckdb
+
+from ... import ops
+from ...config import Settings, get_settings
+from ...connect import LAKE, csv_source, lake_connect, raw_dir, upsert
+from ...download import download
+from ...log import logger
+
+_RAW = "mesh"
+_log = logger.bind(ctx="mesh")
+
+
+# --- download ---
+
+
+def download_descriptors(year: int, settings: Settings | None = None) -> Path:
+    """Download the gzipped descriptor XML (``desc{year}.gz``) to the raw layer."""
+    s = settings or get_settings()
+    return download(f"{s.mesh_xml_base}desc{year}.gz", raw_dir(_RAW, s) / f"desc{year}.xml.gz")
+
+
+def download_qualifiers(year: int, settings: Settings | None = None) -> Path:
+    """Download the qualifier XML (``qual{year}.xml``, ~0.3 MB) to the raw layer."""
+    s = settings or get_settings()
+    return download(f"{s.mesh_xml_base}qual{year}.xml", raw_dir(_RAW, s) / f"qual{year}.xml")
+
+
+# --- stream XML → NDJSON (stdlib iterparse; clears each record to bound memory) ---
+
+
+def _open_xml(path: Path):
+    return gzip.open(path, "rb") if str(path).endswith(".gz") else open(path, "rb")
+
+
+def _text(elem: ET.Element, path: str) -> str | None:
+    found = elem.findtext(path)
+    return found.strip() if found else None
+
+
+def _descriptor_record(elem: ET.Element) -> dict | None:
+    """Pull (ui, name, scope_note, tree_numbers, qualifiers, entry_terms) from a record."""
+    ui = _text(elem, "DescriptorUI")
+    name = _text(elem, "DescriptorName/String")
+    if not ui or not name:
+        return None
+    trees = [t.text.strip() for t in elem.findall("TreeNumberList/TreeNumber") if t.text]
+    quals = [
+        q.findtext("QualifierReferredTo/QualifierUI")
+        for q in elem.findall("AllowableQualifiersList/AllowableQualifier")
+    ]
+    scope: str | None = None
+    terms: list[dict] = []
+    for concept in elem.findall("ConceptList/Concept"):
+        pref_concept = concept.get("PreferredConceptYN") == "Y"
+        if pref_concept and scope is None:
+            scope = _text(concept, "ScopeNote")
+        for term in concept.findall("TermList/Term"):
+            s = _text(term, "String")
+            if s:
+                is_pref = pref_concept and term.get("ConceptPreferredTermYN") == "Y"
+                terms.append({"term": s, "is_preferred": is_pref})
+    return {
+        "descriptor_ui": ui,
+        "name": name,
+        "scope_note": scope,
+        "tree_numbers": trees,
+        "qualifiers": [q for q in quals if q],
+        "entry_terms": terms,
+    }
+
+
+def _qualifier_record(elem: ET.Element) -> dict | None:
+    ui = _text(elem, "QualifierUI")
+    name = _text(elem, "QualifierName/String")
+    if not ui or not name:
+        return None
+    return {"qualifier_ui": ui, "name": name, "abbreviation": _text(elem, "Abbreviation")}
+
+
+def _to_ndjson(xml_path: Path, ndjson_path: Path, record_tag: str, extract) -> int:
+    """Stream ``record_tag`` elements from the XML → gzipped NDJSON via ``extract``."""
+    n = 0
+    with _open_xml(xml_path) as fh, gzip.open(ndjson_path, "wt") as out:
+        for _, elem in ET.iterparse(fh, events=("end",)):
+            if elem.tag != record_tag:
+                continue
+            rec = extract(elem)
+            if rec:
+                out.write(json.dumps(rec, separators=(",", ":")) + "\n")
+                n += 1
+            elem.clear()
+    return n
+
+
+def descriptors_to_ndjson(xml_path: Path | str, ndjson_path: Path | str) -> int:
+    """Stream the descriptor XML → NDJSON (one structured object per descriptor)."""
+    n = _to_ndjson(Path(xml_path), Path(ndjson_path), "DescriptorRecord", _descriptor_record)
+    _log.info("parsed {:,} descriptors → {}", n, Path(ndjson_path).name)
+    return n
+
+
+def qualifiers_to_ndjson(xml_path: Path | str, ndjson_path: Path | str) -> int:
+    """Stream the qualifier XML → NDJSON (one object per qualifier)."""
+    n = _to_ndjson(Path(xml_path), Path(ndjson_path), "QualifierRecord", _qualifier_record)
+    _log.info("parsed {:,} qualifiers → {}", n, Path(ndjson_path).name)
+    return n
+
+
+def materialize_raw(con: duckdb.DuckDBPyConnection, ndjson: Path | str) -> Path:
+    """Bronze: a Parquet from the structured NDJSON (nested lists/structs preserved)."""
+    ndjson = Path(ndjson)
+    raw = ndjson.with_name(ndjson.name.split(".")[0] + ".parquet")
+    con.execute(f"COPY (SELECT * FROM read_json_auto('{ndjson}')) TO '{raw}' (FORMAT parquet);")
+    return raw
+
+
+# --- curate (silver) ---
+
+
+def _descriptor_sql(src: str, version: str, limit: int | None) -> str:
+    limit_sql = f" LIMIT {int(limit)}" if limit else ""
+    return f"""
+        SELECT descriptor_ui, name, scope_note,
+               CAST('{version}' AS VARCHAR) AS snapshot_version
+        FROM read_parquet({src}){limit_sql}
+    """
+
+
+def _tree_sql(src: str, version: str, limit: int | None) -> str:
+    """Explode tree numbers; ``parent_tree_number`` drops the last dotted segment."""
+    limit_sql = f" LIMIT {int(limit)}" if limit else ""
+    return f"""
+        WITH d AS (SELECT descriptor_ui, tree_numbers FROM read_parquet({src}){limit_sql}),
+             ex AS (SELECT descriptor_ui, unnest(tree_numbers) AS tree_number FROM d)
+        SELECT DISTINCT descriptor_ui, tree_number,
+               CASE WHEN tree_number LIKE '%.%'
+                    THEN regexp_replace(tree_number, '\\.[^.]+$', '')
+                    ELSE NULL END AS parent_tree_number,
+               CAST('{version}' AS VARCHAR) AS snapshot_version
+        FROM ex
+    """
+
+
+def _qualifier_sql(src: str, version: str) -> str:
+    return f"""
+        SELECT qualifier_ui, name, abbreviation,
+               CAST('{version}' AS VARCHAR) AS snapshot_version
+        FROM read_parquet({src})
+    """
+
+
+def _descriptor_qualifier_sql(src: str, version: str, limit: int | None) -> str:
+    limit_sql = f" LIMIT {int(limit)}" if limit else ""
+    return f"""
+        WITH d AS (SELECT descriptor_ui, qualifiers FROM read_parquet({src}){limit_sql}),
+             ex AS (SELECT descriptor_ui, unnest(qualifiers) AS qualifier_ui FROM d)
+        SELECT DISTINCT descriptor_ui, qualifier_ui,
+               CAST('{version}' AS VARCHAR) AS snapshot_version
+        FROM ex WHERE qualifier_ui IS NOT NULL
+    """
+
+
+def _entry_term_sql(src: str, version: str, limit: int | None) -> str:
+    """Explode entry terms; collapse duplicate terms, OR-ing the preferred flag."""
+    limit_sql = f" LIMIT {int(limit)}" if limit else ""
+    return f"""
+        WITH d AS (SELECT descriptor_ui, entry_terms FROM read_parquet({src}){limit_sql}),
+             ex AS (SELECT descriptor_ui, unnest(entry_terms) AS et FROM d)
+        SELECT descriptor_ui, et.term AS term,
+               bool_or(et.is_preferred) AS is_preferred,
+               CAST('{version}' AS VARCHAR) AS snapshot_version
+        FROM ex WHERE et.term IS NOT NULL
+        GROUP BY descriptor_ui, et.term
+    """
+
+
+def curate(
+    con: duckdb.DuckDBPyConnection,
+    descriptor_parquet: Path | str,
+    qualifier_parquet: Path | str,
+    *,
+    schema: str = "mesh",
+    version: str = "0",
+    limit: int | None = None,
+) -> dict[str, int]:
+    """Upsert the five MeSH tables from the bronze descriptor + qualifier Parquets."""
+    d = csv_source(str(descriptor_parquet))
+    q = csv_source(str(qualifier_parquet))
+    ex = ["snapshot_version"]
+    counts = {
+        "descriptor": upsert(
+            con, f"{LAKE}.{schema}.descriptor", _descriptor_sql(d, version, limit),
+            "descriptor_ui", exclude_change_cols=ex,
+        ),
+        "tree": upsert(
+            con, f"{LAKE}.{schema}.tree", _tree_sql(d, version, limit),
+            ["descriptor_ui", "tree_number"], exclude_change_cols=ex,
+        ),
+        "qualifier": upsert(
+            con, f"{LAKE}.{schema}.qualifier", _qualifier_sql(q, version),
+            "qualifier_ui", exclude_change_cols=ex,
+        ),
+        "descriptor_qualifier": upsert(
+            con, f"{LAKE}.{schema}.descriptor_qualifier",
+            _descriptor_qualifier_sql(d, version, limit),
+            ["descriptor_ui", "qualifier_ui"], exclude_change_cols=ex,
+        ),
+        "entry_term": upsert(
+            con, f"{LAKE}.{schema}.entry_term", _entry_term_sql(d, version, limit),
+            ["descriptor_ui", "term"], exclude_change_cols=ex,
+        ),
+    }
+    for table, n in counts.items():
+        _log.info("mesh.{} <- {:,} rows", table, n)
+    return counts
+
+
+def ingest(
+    *,
+    year: int | None = None,
+    descriptor_file: str | None = None,
+    qualifier_file: str | None = None,
+    schema: str = "mesh",
+    limit: int | None = None,
+    settings: Settings | None = None,
+) -> dict:
+    """End-to-end: download → stream NDJSON → bronze Parquet → upsert five tables.
+
+    ``descriptor_file`` / ``qualifier_file`` load a local ``.xml``/``.gz`` (or an
+    already-materialized ``.parquet``), skipping the download for that artifact.
+    """
+    s = settings or get_settings()
+    year = year or s.mesh_year
+    version = str(year)
+    con = lake_connect(s)
+    try:
+        desc_raw = _bronze(con, descriptor_file, lambda: download_descriptors(year, s),
+                           descriptors_to_ndjson, f"desc{year}", s)
+        qual_raw = _bronze(con, qualifier_file, lambda: download_qualifiers(year, s),
+                           qualifiers_to_ndjson, f"qual{year}", s)
+        with ops.run(con, source="mesh", target=f"{LAKE}.{schema}", version=version) as r:
+            counts = curate(con, desc_raw, qual_raw, schema=schema, version=version, limit=limit)
+            r.rows = sum(counts.values())
+    finally:
+        con.close()
+    return {**r.summary(), "schema": f"{LAKE}.{schema}", **counts}
+
+
+def _bronze(con, file, fetch, to_ndjson, stem, settings) -> Path:
+    """Resolve one artifact to a bronze Parquet: parquet passthrough, else XML→NDJSON→Parquet."""
+    if file and str(file).endswith(".parquet"):
+        return Path(file)
+    xml = Path(file) if file else fetch()
+    ndjson = raw_dir(_RAW, settings) / f"{stem}.ndjson.gz"
+    to_ndjson(xml, ndjson)
+    return materialize_raw(con, ndjson)

--- a/tests/fixtures/mesh_desc_sample.xml
+++ b/tests/fixtures/mesh_desc_sample.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DescriptorRecordSet>
+  <DescriptorRecord DescriptorClass="1">
+    <DescriptorUI>D000001</DescriptorUI>
+    <DescriptorName><String>Calcimycin</String></DescriptorName>
+    <AllowableQualifiersList>
+      <AllowableQualifier>
+        <QualifierReferredTo>
+          <QualifierUI>Q000008</QualifierUI>
+          <QualifierName><String>administration &amp; dosage</String></QualifierName>
+        </QualifierReferredTo>
+      </AllowableQualifier>
+    </AllowableQualifiersList>
+    <TreeNumberList>
+      <TreeNumber>D03.633.100.221.173</TreeNumber>
+    </TreeNumberList>
+    <ConceptList>
+      <Concept PreferredConceptYN="Y">
+        <ScopeNote>An ionophorous, polyether antibiotic from Streptomyces chartreusensis.</ScopeNote>
+        <TermList>
+          <Term ConceptPreferredTermYN="Y"><String>Calcimycin</String></Term>
+          <Term ConceptPreferredTermYN="N"><String>A-23187</String></Term>
+        </TermList>
+      </Concept>
+    </ConceptList>
+  </DescriptorRecord>
+  <DescriptorRecord DescriptorClass="1">
+    <DescriptorUI>D009369</DescriptorUI>
+    <DescriptorName><String>Neoplasms</String></DescriptorName>
+    <AllowableQualifiersList>
+      <AllowableQualifier>
+        <QualifierReferredTo>
+          <QualifierUI>Q000235</QualifierUI>
+          <QualifierName><String>genetics</String></QualifierName>
+        </QualifierReferredTo>
+      </AllowableQualifier>
+    </AllowableQualifiersList>
+    <TreeNumberList>
+      <TreeNumber>C04</TreeNumber>
+      <TreeNumber>C04.557</TreeNumber>
+    </TreeNumberList>
+    <ConceptList>
+      <Concept PreferredConceptYN="Y">
+        <ScopeNote>New abnormal growth of tissue. Malignant neoplasms show degrees of anaplasia.</ScopeNote>
+        <TermList>
+          <Term ConceptPreferredTermYN="Y"><String>Neoplasms</String></Term>
+          <Term ConceptPreferredTermYN="N"><String>Tumors</String></Term>
+        </TermList>
+      </Concept>
+    </ConceptList>
+  </DescriptorRecord>
+</DescriptorRecordSet>

--- a/tests/fixtures/mesh_qual_sample.xml
+++ b/tests/fixtures/mesh_qual_sample.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<QualifierRecordSet>
+  <QualifierRecord>
+    <QualifierUI>Q000008</QualifierUI>
+    <QualifierName><String>administration &amp; dosage</String></QualifierName>
+    <Abbreviation>AD</Abbreviation>
+  </QualifierRecord>
+  <QualifierRecord>
+    <QualifierUI>Q000235</QualifierUI>
+    <QualifierName><String>genetics</String></QualifierName>
+    <Abbreviation>GE</Abbreviation>
+  </QualifierRecord>
+</QualifierRecordSet>

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -1,0 +1,98 @@
+"""Offline tests for the MeSH ingestor (ADR-0010).
+
+Parse the descriptor + qualifier XML fixtures → bronze Parquet → curate the five
+silver tables, asserting the vocabulary shape and — the point of MeSH — the tree
+hierarchy (parent derivation + prefix rollup). No network.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from cdsci.lake import Settings, lake_connect
+from cdsci.lake.sources import mesh
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture
+def lake_settings(tmp_path: Path) -> Settings:
+    return Settings(storage_base_uri=f"file://{tmp_path}")
+
+
+def test_mesh_curate_vocabulary_and_hierarchy(lake_settings: Settings, tmp_path: Path):
+    desc_nd = tmp_path / "desc.ndjson.gz"
+    qual_nd = tmp_path / "qual.ndjson.gz"
+    assert mesh.descriptors_to_ndjson(FIXTURES / "mesh_desc_sample.xml", desc_nd) == 2
+    assert mesh.qualifiers_to_ndjson(FIXTURES / "mesh_qual_sample.xml", qual_nd) == 2
+
+    con = lake_connect(lake_settings)
+    try:
+        desc_raw = mesh.materialize_raw(con, desc_nd)
+        qual_raw = mesh.materialize_raw(con, qual_nd)
+        counts = mesh.curate(con, desc_raw, qual_raw, version="2026")
+        assert counts == {
+            "descriptor": 2,
+            "tree": 3,  # D03.633.100.221.173 + C04 + C04.557
+            "qualifier": 2,
+            "descriptor_qualifier": 2,
+            "entry_term": 4,  # two terms per descriptor
+        }
+
+        # The hierarchy: parent of C04.557 is C04; C04 is top-level (NULL parent).
+        assert con.execute(
+            "SELECT parent_tree_number FROM lake.mesh.tree WHERE tree_number = 'C04.557'"
+        ).fetchone()[0] == "C04"
+        assert con.execute(
+            "SELECT parent_tree_number FROM lake.mesh.tree WHERE tree_number = 'C04'"
+        ).fetchone()[0] is None
+        # "Everything under Neoplasms (C04)" is a prefix query — both tree rows match.
+        assert con.execute(
+            "SELECT count(*) FROM lake.mesh.tree WHERE tree_number LIKE 'C04%'"
+        ).fetchone()[0] == 2
+
+        # Descriptor name + scope note carried through.
+        name, scope = con.execute(
+            "SELECT name, scope_note FROM lake.mesh.descriptor WHERE descriptor_ui = 'D009369'"
+        ).fetchone()
+        assert name == "Neoplasms" and scope.startswith("New abnormal growth")
+
+        # Entry terms: the descriptor name is preferred, the synonym is not.
+        assert con.execute(
+            "SELECT is_preferred FROM lake.mesh.entry_term WHERE term = 'Neoplasms'"
+        ).fetchone()[0] is True
+        assert con.execute(
+            "SELECT is_preferred FROM lake.mesh.entry_term WHERE term = 'Tumors'"
+        ).fetchone()[0] is False
+
+        # Allowable-qualifier bridge + the qualifier dimension.
+        assert con.execute(
+            "SELECT qualifier_ui FROM lake.mesh.descriptor_qualifier "
+            "WHERE descriptor_ui = 'D009369'"
+        ).fetchone()[0] == "Q000235"
+        assert con.execute(
+            "SELECT name FROM lake.mesh.qualifier WHERE qualifier_ui = 'Q000008'"
+        ).fetchone()[0] == "administration & dosage"
+    finally:
+        con.close()
+
+
+def test_mesh_curate_idempotent(lake_settings: Settings, tmp_path: Path):
+    """A re-curate of identical data is a no-op (adds no snapshot)."""
+    desc_nd = tmp_path / "desc.ndjson.gz"
+    qual_nd = tmp_path / "qual.ndjson.gz"
+    mesh.descriptors_to_ndjson(FIXTURES / "mesh_desc_sample.xml", desc_nd)
+    mesh.qualifiers_to_ndjson(FIXTURES / "mesh_qual_sample.xml", qual_nd)
+    con = lake_connect(lake_settings)
+    try:
+        desc_raw = mesh.materialize_raw(con, desc_nd)
+        qual_raw = mesh.materialize_raw(con, qual_nd)
+        mesh.curate(con, desc_raw, qual_raw, version="2026")
+        before = con.execute("SELECT max(snapshot_id) FROM lake.snapshots()").fetchone()[0]
+        mesh.curate(con, desc_raw, qual_raw, version="2026")  # identical re-run
+        after = con.execute("SELECT max(snapshot_id) FROM lake.snapshots()").fetchone()[0]
+        assert after == before
+    finally:
+        con.close()


### PR DESCRIPTION
Implements ADR-0010 Phase 1a — the MeSH vocabulary + hierarchy as a new `mesh` source, following the ctgov medallion pattern.

## What
Download annual descriptor + qualifier XML → **stdlib `xml.etree.iterparse`** (no new dependency) → gzip NDJSON → bronze Parquet → five MERGE-upsert tables:
- `mesh.descriptor` (`descriptor_ui`, `name`, `scope_note`)
- `mesh.tree` — **the hierarchy**: exploded `(descriptor_ui, tree_number)` + derived `parent_tree_number`. Polyhierarchy native; `tree_number LIKE 'C04%'` rolls up "everything under Neoplasms"; recursive CTEs for deep traversal.
- `mesh.qualifier`, `mesh.descriptor_qualifier` (allowable bridge), `mesh.entry_term` (`is_preferred` flags the descriptor name)

Registered in `ops.SOURCES`; CLI has the standard `--log-level` callback; because writes go through `upsert`, snapshots are attributed (ADR-0008) and idempotent (ADR-0003) for free.

## Not in scope
The literature edge `mesh.article_heading` (from `omicidx.pubmed_article.mesh_terms`) is Phase 1b; SCRs deferred.

## Test plan
- `uv run ruff check src/ tests/` — clean
- `uv run pytest -q` — 28 passed, 3 skipped (new `test_mesh.py`: parses XML fixtures, asserts vocabulary + tree parent derivation + `C04%` prefix rollup + idempotency)
- `python -m cdsci.lake.sources.mesh run --help` loads; `mesh` registered in the source registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)