### PR TITLE
MeSH Phase 1b: mesh.article_heading edge (ADR-0010)

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -79,9 +79,13 @@ cdsci-lake` and `lake_connect(read_only=True)`.
   `mesh.tree` (exploded `(descriptor_ui, tree_number)` + `parent_tree_number`;
   polyhierarchy native — `tree_number LIKE 'C04%'` rolls up "everything under
   Neoplasms"), `mesh.qualifier`, `mesh.descriptor_qualifier`, `mesh.entry_term`.
-  Complementary to `openalex.topics`. The literature edge (`mesh.article_heading`
-  from `omicidx.pubmed_article.mesh_terms`, which carries the `D…`/`Q…` UIs) is
-  Phase 1b. See ADR-0010. To load: `python -m cdsci.lake.sources.mesh run`.
+  Complementary to `openalex.topics`. **Phase 1b** (`mesh.article_heading`) is also
+  built — `(pmid, descriptor_ui, qualifier_ui)` exploded from
+  `omicidx.pubmed_article.mesh_terms` (carries the `D…`/`Q…` UIs; `''` sentinel for
+  no-qualifier; major-topic flag is the known gap). `descriptor_ui` joins
+  `mesh.tree` for rollups, `pmid` joins `icite`/`publink`. **No `mesh↔openalex_topic`
+  crosswalk** — researched, none is canonical (ADR-0010). See ADR-0010. To load:
+  `python -m cdsci.lake.sources.mesh run` (vocab) then `… mesh headings` (the edge).
 - **MERGE-upsert** (`cdsci.lake.upsert`, ADR-0003) — keyed, change-detecting (updates
   only on real diffs), idempotent (no-op re-run adds no snapshot) → meaningful
   time-travel. Per-load stamps (`snapshot_version`) are excluded from change-detection

--- a/docs/adr/0010-mesh-vocabulary.md
+++ b/docs/adr/0010-mesh-vocabulary.md
@@ -72,9 +72,18 @@ annual cadence; `us-public-domain` / NLM). Two phases.
 
 ### Out of scope / later
 
-Supplementary Concept Records, PharmacologicalActions, see-also cross-refs (Phase 2),
-and a `mesh ↔ openalex_topic` crosswalk (optional, if a unified subject layer is
-wanted). MeSH and OpenAlex topics stay distinct vocabularies.
+Supplementary Concept Records, PharmacologicalActions, see-also cross-refs (Phase 2).
+
+**No `mesh ↔ openalex_topic` crosswalk** — researched, and **no canonical mapping
+exists**: an OpenAlex Topic exposes only an OpenAlex id + a single Wikipedia URL (no
+MeSH/UMLS/Wikidata), UMLS does not include OpenAlex topics, and the only published
+alignment is a *derived, approximate* third-party paper. Per "build it only if
+canonical", we do not. A derived bridge (topic → Wikipedia → Wikidata P486 → MeSH)
+is possible but lossy and must be labelled non-canonical if ever built. Note the
+real authoritative literature↔MeSH bridge is **PMID → MeSH** — which Phase 1b
+provides — and that OpenAlex's *work-level* `mesh` field carries `is_major_topic`
+(the flag omicidx's flattening drops), an alternative source for the Phase 2
+major-topic upgrade should `openalex.works` ever keep `mesh`.
 
 ## Consequences
 

--- a/src/cdsci/lake/sources/mesh/__init__.py
+++ b/src/cdsci/lake/sources/mesh/__init__.py
@@ -13,22 +13,28 @@ Five tables (Phase 1a — the vocabulary):
   qualifier_ui)``.
 * ``mesh.entry_term`` — synonyms ``(descriptor_ui, term, is_preferred)``.
 
-The literature edge (``mesh.article_heading`` exploded from ``omicidx.pubmed_article
-.mesh_terms``, which carries the ``D…``/``Q…`` UIs) is Phase 1b — not built here.
+Phase 1b adds the literature edge ``mesh.article_heading`` — ``(pmid,
+descriptor_ui, qualifier_ui)`` exploded from ``omicidx.pubmed_article.mesh_terms``
+(which carries the ``D…``/``Q…`` UIs). ``descriptor_ui`` joins ``mesh.tree`` for
+hierarchy rollups; ``pmid`` joins ``icite``/``reporter.publink``.
 """
 
 from .ingest import (
     curate,
+    curate_article_headings,
     descriptors_to_ndjson,
     ingest,
+    ingest_headings,
     materialize_raw,
     qualifiers_to_ndjson,
 )
 
 __all__ = [
     "curate",
+    "curate_article_headings",
     "descriptors_to_ndjson",
     "ingest",
+    "ingest_headings",
     "materialize_raw",
     "qualifiers_to_ndjson",
 ]

--- a/src/cdsci/lake/sources/mesh/__main__.py
+++ b/src/cdsci/lake/sources/mesh/__main__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import typer
 
 from ...log import configure
-from .ingest import ingest
+from .ingest import ingest, ingest_headings
 
 app = typer.Typer(
     help="Ingest NLM MeSH descriptors + tree hierarchy + qualifiers into lake.mesh.*.",
@@ -41,6 +41,23 @@ def run(
     counts = {k: s[k] for k in
               ("descriptor", "tree", "qualifier", "descriptor_qualifier", "entry_term")}
     typer.echo(f"{s['schema']} <- {s['rows']:,} rows — {delta}: {counts}")
+
+
+@app.command("headings")
+def headings(
+    version: str | None = typer.Option(
+        None, "--version", help="Snapshot label (default: YYYY-MM)."
+    ),
+    source_table: str = typer.Option(
+        "lake.omicidx.pubmed_article", "--source-table", help="In-lake PubMed source."
+    ),
+    schema: str = typer.Option("mesh", "--schema", help="Target lake schema."),
+    limit: int | None = typer.Option(None, "--limit", help="Cap source articles (smoke test)."),
+) -> None:
+    """Build mesh.article_heading (pmid↔descriptor↔qualifier) from omicidx PubMed MeSH."""
+    s = ingest_headings(version=version, source_table=source_table, schema=schema, limit=limit)
+    delta = "changed" if s["changed"] else "no change (idempotent)"
+    typer.echo(f"{s['table']} <- {s['rows']:,} rows — {delta}")
 
 
 if __name__ == "__main__":

--- a/src/cdsci/lake/sources/mesh/ingest.py
+++ b/src/cdsci/lake/sources/mesh/ingest.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import gzip
 import json
 import xml.etree.ElementTree as ET
+from datetime import date
 from pathlib import Path
 
 import duckdb
@@ -285,3 +286,101 @@ def _bronze(con, file, fetch, to_ndjson, stem, settings) -> Path:
     ndjson = raw_dir(_RAW, settings) / f"{stem}.ndjson.gz"
     to_ndjson(xml, ndjson)
     return materialize_raw(con, ndjson)
+
+
+# --- Phase 1b: the literature edge (article ↔ MeSH), derived from omicidx PubMed ---
+
+_PUBMED = "lake.omicidx.pubmed_article"
+
+
+def _today_version() -> str:
+    """Default snapshot label (the pull month) — the edge tracks an omicidx snapshot."""
+    return date.today().strftime("%Y-%m")
+
+
+def _article_heading_sql(source_table: str, version: str, limit: int | None) -> str:
+    """Explode ``mesh_terms`` (``D…:Name [/ Q…:qual]*; …``) → (pmid, descriptor, qualifier).
+
+    A heading with no qualifier emits one row with ``qualifier_ui = ''`` (a sentinel,
+    never NULL, so the MERGE key stays matchable and re-runs are idempotent); a
+    heading with N qualifiers emits N rows. The major/minor-topic flag is not present
+    in the flattened ``mesh_terms`` (ADR-0010 known gap). ``limit`` caps source rows.
+    """
+    limit_sql = f" LIMIT {int(limit)}" if limit else ""
+    return rf"""
+        WITH src AS (
+            SELECT TRY_CAST(pmid AS BIGINT) AS pmid, mesh_terms
+            FROM {source_table}
+            WHERE mesh_terms IS NOT NULL AND mesh_terms <> ''{limit_sql}
+        ),
+        headings AS (
+            SELECT pmid, trim(h) AS heading
+            FROM src, unnest(string_split(mesh_terms, ';')) AS t(h)
+            WHERE trim(h) <> ''
+        ),
+        parsed AS (
+            SELECT pmid,
+                   regexp_extract(heading, '^(D\d+)', 1)  AS descriptor_ui,
+                   regexp_extract_all(heading, '(Q\d+)')  AS quals
+            FROM headings
+        ),
+        valid AS (SELECT * FROM parsed WHERE pmid IS NOT NULL AND descriptor_ui <> '')
+        SELECT pmid, descriptor_ui, '' AS qualifier_ui,
+               CAST('{version}' AS VARCHAR) AS snapshot_version
+        FROM valid WHERE len(quals) = 0
+        UNION
+        SELECT pmid, descriptor_ui, unnest(quals) AS qualifier_ui,
+               CAST('{version}' AS VARCHAR) AS snapshot_version
+        FROM valid WHERE len(quals) > 0
+    """
+
+
+def curate_article_headings(
+    con: duckdb.DuckDBPyConnection,
+    *,
+    schema: str = "mesh",
+    version: str = "0",
+    source_table: str = _PUBMED,
+    limit: int | None = None,
+) -> int:
+    """Upsert ``mesh.article_heading`` (pmid ↔ descriptor ↔ qualifier) from PubMed MeSH.
+
+    Reads the in-lake ``omicidx.pubmed_article.mesh_terms`` (which carries the
+    ``D…``/``Q…`` UIs) and explodes it; ``descriptor_ui`` joins ``mesh.tree`` for
+    hierarchy rollups and ``pmid`` joins ``icite``/``reporter.publink``. This is a
+    **large** table (one row per article × heading × qualifier — hundreds of M);
+    the MERGE re-reads the target, so a full rebuild is heavy by design.
+    """
+    n = upsert(
+        con,
+        f"{LAKE}.{schema}.article_heading",
+        _article_heading_sql(source_table, version, limit),
+        ["pmid", "descriptor_ui", "qualifier_ui"],
+        exclude_change_cols=["snapshot_version"],
+    )
+    _log.info("mesh.article_heading <- {:,} rows", n)
+    return n
+
+
+def ingest_headings(
+    *,
+    schema: str = "mesh",
+    version: str | None = None,
+    source_table: str = _PUBMED,
+    limit: int | None = None,
+    settings: Settings | None = None,
+) -> dict:
+    """Build ``mesh.article_heading`` from omicidx PubMed (Phase 1b). No download."""
+    s = settings or get_settings()
+    version = version or _today_version()
+    con = lake_connect(s)
+    try:
+        with ops.run(
+            con, source="mesh", target=f"{LAKE}.{schema}.article_heading", version=version
+        ) as r:
+            r.rows = curate_article_headings(
+                con, schema=schema, version=version, source_table=source_table, limit=limit
+            )
+    finally:
+        con.close()
+    return {**r.summary(), "table": f"{LAKE}.{schema}.article_heading"}

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -79,6 +79,46 @@ def test_mesh_curate_vocabulary_and_hierarchy(lake_settings: Settings, tmp_path:
         con.close()
 
 
+def test_mesh_article_headings_explosion(lake_settings: Settings):
+    """Phase 1b: explode omicidx mesh_terms → (pmid, descriptor_ui, qualifier_ui)."""
+    con = lake_connect(lake_settings)
+    try:
+        # stand up a tiny in-lake omicidx.pubmed_article (pmid VARCHAR, like production).
+        con.execute("CREATE SCHEMA lake.omicidx;")
+        con.execute(
+            "CREATE TABLE lake.omicidx.pubmed_article AS SELECT * FROM (VALUES "
+            "('100', 'D006801:Humans; D015820:Cadherins / Q000378:metabolism / Q000235:genetics'), "
+            "('200', 'D000328:Adult; D000653:Amniotic Fluid / Q000737:chemistry'), "
+            "('300', NULL)) t(pmid, mesh_terms);"
+        )
+        n = mesh.curate_article_headings(con, version="2026-06")
+        # 100: Humans=1 + Cadherins×2 quals=2 → 3 ; 200: Adult=1 + Amniotic/chem=1 → 2 ; 300 skip
+        assert n == 5
+        got = {
+            tuple(r) for r in con.execute(
+                "SELECT pmid, descriptor_ui, qualifier_ui FROM lake.mesh.article_heading"
+            ).fetchall()
+        }
+        assert got == {
+            (100, "D006801", ""),
+            (100, "D015820", "Q000378"),
+            (100, "D015820", "Q000235"),
+            (200, "D000328", ""),
+            (200, "D000653", "Q000737"),
+        }
+        # pmid normalized to BIGINT (joins icite/publink); no-qualifier sentinel is '', not NULL.
+        assert con.execute(
+            "SELECT count(*) FROM lake.mesh.article_heading WHERE qualifier_ui IS NULL"
+        ).fetchone()[0] == 0
+        # idempotent re-run adds no snapshot.
+        before = con.execute("SELECT max(snapshot_id) FROM lake.snapshots()").fetchone()[0]
+        mesh.curate_article_headings(con, version="2026-06")
+        after = con.execute("SELECT max(snapshot_id) FROM lake.snapshots()").fetchone()[0]
+        assert after == before
+    finally:
+        con.close()
+
+
 def test_mesh_curate_idempotent(lake_settings: Settings, tmp_path: Path):
     """A re-curate of identical data is a no-op (adds no snapshot)."""
     desc_nd = tmp_path / "desc.ndjson.gz"


### PR DESCRIPTION
Phase 1b of ADR-0010 — the literature↔MeSH edge — plus the crosswalk decision.

## What
- **`mesh.article_heading` (pmid, descriptor_ui, qualifier_ui)** — exploded from `omicidx.pubmed_article.mesh_terms` (which carries `D…`/`Q…` UIs). No-qualifier headings use a `''` sentinel (never NULL → MERGE key stays matchable → idempotent); multi-qualifier headings fan out one row each. `pmid` normalized to BIGINT (joins `icite`/`publink`); `descriptor_ui` joins `mesh.tree` for hierarchy rollups. Major-topic flag is the known ADR-0010 gap.
- New `curate_article_headings` / `ingest_headings` and a **`mesh headings`** CLI command (separate from `mesh run`, since the source is the lake's own omicidx, not the XML).

## Crosswalk decision (researched)
**No canonical `mesh ↔ openalex_topic` crosswalk exists** — OpenAlex Topics expose only an OpenAlex id + a Wikipedia URL (no MeSH/UMLS/Wikidata); UMLS doesn't include OpenAlex topics; the only published alignment is a *derived, approximate* third-party paper. Per "only if canonical", **not built**. Recorded in ADR-0010. The authoritative literature↔MeSH bridge is PMID→MeSH — which this edge provides.

## Note on scale
`article_heading` is large (article × heading × qualifier — hundreds of M); the MERGE re-reads the target, so a full rebuild is heavy by design. Build with `mesh headings` after `mesh run`.

## Test plan
- `uv run ruff check src/ tests/` — clean
- `uv run pytest -q` — 29 passed, 3 skipped (new `test_mesh_article_headings_explosion`: fans out qualifiers, `''` sentinel, BIGINT pmid, idempotent re-run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)