### PR TITLE
MeSH Phase 2: Supplementary Concept Records + pharmacological actions

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -84,8 +84,12 @@ cdsci-lake` and `lake_connect(read_only=True)`.
   `omicidx.pubmed_article.mesh_terms` (carries the `D…`/`Q…` UIs; `''` sentinel for
   no-qualifier; major-topic flag is the known gap). `descriptor_ui` joins
   `mesh.tree` for rollups, `pmid` joins `icite`/`publink`. **No `mesh↔openalex_topic`
-  crosswalk** — researched, none is canonical (ADR-0010). See ADR-0010. To load:
-  `python -m cdsci.lake.sources.mesh run` (vocab) then `… mesh headings` (the edge).
+  crosswalk** — researched, none is canonical (ADR-0010). **Phase 2 (drug/chemical
+  layer) is also built:** `mesh.supplemental` (SCRs — chemicals/substances),
+  `mesh.supplemental_descriptor` (SCR→descriptor heading-mapped-to bridge),
+  `mesh.supplemental_term`, and `mesh.pharmacological_action` (substance↔mechanism).
+  See ADR-0010. To load: `mesh run` (vocab), `mesh headings` (literature edge),
+  `mesh supplemental` (SCRs, ~786 MB), `mesh actions` (pharm actions).
 - **MERGE-upsert** (`cdsci.lake.upsert`, ADR-0003) — keyed, change-detecting (updates
   only on real diffs), idempotent (no-op re-run adds no snapshot) → meaningful
   time-travel. Per-load stamps (`snapshot_version`) are excluded from change-detection

--- a/docs/adr/0010-mesh-vocabulary.md
+++ b/docs/adr/0010-mesh-vocabulary.md
@@ -70,9 +70,20 @@ annual cadence; `us-public-domain` / NLM). Two phases.
   **upstream in omicidx** rather than re-parsed here. Tracked as a Phase 2 upgrade;
   Phase 1b ships without it.
 
-### Out of scope / later
+### Phase 2 — the drug/chemical layer (built)
 
-Supplementary Concept Records, PharmacologicalActions, see-also cross-refs (Phase 2).
+- `mesh.supplemental` — Supplementary Concept Records (~330k specific
+  chemicals/substances; `scr_class` 1 chemical/2 disease/3 protocol/4 organism;
+  `registry_number` = UNII/CAS), from `supp{year}.gz` (~786 MB, daily upstream).
+- `mesh.supplemental_descriptor` — the **heading-mapped-to** bridge: an SCR is mapped
+  to descriptor(s) (the link *into* the tree, since SCRs have no tree numbers), with
+  `is_primary` from the `*` prefix.
+- `mesh.supplemental_term` — SCR synonyms.
+- `mesh.pharmacological_action` — `(substance_ui, action_ui)`, what each
+  drug/substance *does* (query literature by mechanism/effect), from `pa{year}.xml`.
+
+Still later: see-also cross-refs; a PubMed `ChemicalList` → SCR article edge (the
+chemical analogue of `article_heading`).
 
 **No `mesh ↔ openalex_topic` crosswalk** — researched, and **no canonical mapping
 exists**: an OpenAlex Topic exposes only an OpenAlex id + a single Wikipedia URL (no

--- a/src/cdsci/lake/sources/mesh/__init__.py
+++ b/src/cdsci/lake/sources/mesh/__init__.py
@@ -17,24 +17,42 @@ Phase 1b adds the literature edge ``mesh.article_heading`` — ``(pmid,
 descriptor_ui, qualifier_ui)`` exploded from ``omicidx.pubmed_article.mesh_terms``
 (which carries the ``D…``/``Q…`` UIs). ``descriptor_ui`` joins ``mesh.tree`` for
 hierarchy rollups; ``pmid`` joins ``icite``/``reporter.publink``.
+
+Phase 2 adds the drug/chemical layer: ``mesh.supplemental`` (SCRs — specific
+chemicals/substances, ``scr_class`` 1 chemical/2 disease/3 protocol/4 organism),
+``mesh.supplemental_descriptor`` (the heading-mapped-to bridge SCR→descriptor, with
+``is_primary``), ``mesh.supplemental_term`` (SCR synonyms), and
+``mesh.pharmacological_action`` (substance ↔ mechanism/effect descriptor).
 """
 
 from .ingest import (
     curate,
     curate_article_headings,
+    curate_pharmacological_actions,
+    curate_supplemental,
     descriptors_to_ndjson,
     ingest,
     ingest_headings,
+    ingest_pharmacological_actions,
+    ingest_supplemental,
     materialize_raw,
+    pharmacological_actions_to_ndjson,
     qualifiers_to_ndjson,
+    supplemental_to_ndjson,
 )
 
 __all__ = [
     "curate",
     "curate_article_headings",
+    "curate_pharmacological_actions",
+    "curate_supplemental",
     "descriptors_to_ndjson",
     "ingest",
     "ingest_headings",
+    "ingest_pharmacological_actions",
+    "ingest_supplemental",
     "materialize_raw",
+    "pharmacological_actions_to_ndjson",
     "qualifiers_to_ndjson",
+    "supplemental_to_ndjson",
 ]

--- a/src/cdsci/lake/sources/mesh/__main__.py
+++ b/src/cdsci/lake/sources/mesh/__main__.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import typer
 
 from ...log import configure
-from .ingest import ingest, ingest_headings
+from .ingest import (
+    ingest,
+    ingest_headings,
+    ingest_pharmacological_actions,
+    ingest_supplemental,
+)
 
 app = typer.Typer(
     help="Ingest NLM MeSH descriptors + tree hierarchy + qualifiers into lake.mesh.*.",
@@ -56,6 +61,36 @@ def headings(
 ) -> None:
     """Build mesh.article_heading (pmid↔descriptor↔qualifier) from omicidx PubMed MeSH."""
     s = ingest_headings(version=version, source_table=source_table, schema=schema, limit=limit)
+    delta = "changed" if s["changed"] else "no change (idempotent)"
+    typer.echo(f"{s['table']} <- {s['rows']:,} rows — {delta}")
+
+
+@app.command("supplemental")
+def supplemental(
+    year: int | None = typer.Option(None, "--year", help="MeSH edition (default: config)."),
+    file: str | None = typer.Option(
+        None, "--file", help="Local supp XML/.gz/.parquet instead of downloading."
+    ),
+    schema: str = typer.Option("mesh", "--schema", help="Target lake schema."),
+    limit: int | None = typer.Option(None, "--limit", help="Cap SCRs (smoke test)."),
+) -> None:
+    """Load Supplementary Concept Records (chemicals/substances) — supp{year}.gz is ~786 MB."""
+    s = ingest_supplemental(year=year, file=file, schema=schema, limit=limit)
+    delta = "changed" if s["changed"] else "no change (idempotent)"
+    counts = {k: s[k] for k in ("supplemental", "supplemental_descriptor", "supplemental_term")}
+    typer.echo(f"{s['schema']} <- {s['rows']:,} rows — {delta}: {counts}")
+
+
+@app.command("actions")
+def actions(
+    year: int | None = typer.Option(None, "--year", help="MeSH edition (default: config)."),
+    file: str | None = typer.Option(
+        None, "--file", help="Local pa XML/.parquet instead of downloading."
+    ),
+    schema: str = typer.Option("mesh", "--schema", help="Target lake schema."),
+) -> None:
+    """Load the pharmacological-action cross-reference (substance ↔ mechanism/effect)."""
+    s = ingest_pharmacological_actions(year=year, file=file, schema=schema)
     delta = "changed" if s["changed"] else "no change (idempotent)"
     typer.echo(f"{s['table']} <- {s['rows']:,} rows — {delta}")
 

--- a/src/cdsci/lake/sources/mesh/ingest.py
+++ b/src/cdsci/lake/sources/mesh/ingest.py
@@ -80,25 +80,34 @@ def _descriptor_record(elem: ET.Element) -> dict | None:
         q.findtext("QualifierReferredTo/QualifierUI")
         for q in elem.findall("AllowableQualifiersList/AllowableQualifier")
     ]
-    scope: str | None = None
-    terms: list[dict] = []
-    for concept in elem.findall("ConceptList/Concept"):
-        pref_concept = concept.get("PreferredConceptYN") == "Y"
-        if pref_concept and scope is None:
-            scope = _text(concept, "ScopeNote")
-        for term in concept.findall("TermList/Term"):
-            s = _text(term, "String")
-            if s:
-                is_pref = pref_concept and term.get("ConceptPreferredTermYN") == "Y"
-                terms.append({"term": s, "is_preferred": is_pref})
+    scope = next(
+        (_text(c, "ScopeNote") for c in elem.findall("ConceptList/Concept")
+         if c.get("PreferredConceptYN") == "Y"),
+        None,
+    )
     return {
         "descriptor_ui": ui,
         "name": name,
         "scope_note": scope,
         "tree_numbers": trees,
         "qualifiers": [q for q in quals if q],
-        "entry_terms": terms,
+        "entry_terms": _entry_terms(elem),
     }
+
+
+def _entry_terms(elem: ET.Element) -> list[dict]:
+    """All Concept/Term strings as ``{term, is_preferred}`` (preferred = the record name)."""
+    out: list[dict] = []
+    for concept in elem.findall("ConceptList/Concept"):
+        pref_concept = concept.get("PreferredConceptYN") == "Y"
+        for term in concept.findall("TermList/Term"):
+            s = _text(term, "String")
+            if s:
+                out.append({
+                    "term": s,
+                    "is_preferred": pref_concept and term.get("ConceptPreferredTermYN") == "Y",
+                })
+    return out
 
 
 def _qualifier_record(elem: ET.Element) -> dict | None:
@@ -384,3 +393,230 @@ def ingest_headings(
     finally:
         con.close()
     return {**r.summary(), "table": f"{LAKE}.{schema}.article_heading"}
+
+
+# --- Phase 2: Supplementary Concept Records (chemicals/substances) + Pharm Actions ---
+
+
+def download_supplemental(year: int, settings: Settings | None = None) -> Path:
+    """Download the gzipped SCR XML (``supp{year}.gz``, ~786 MB raw) to the raw layer."""
+    s = settings or get_settings()
+    return download(f"{s.mesh_xml_base}supp{year}.gz", raw_dir(_RAW, s) / f"supp{year}.xml.gz")
+
+
+def download_pharmacological_actions(year: int, settings: Settings | None = None) -> Path:
+    """Download the pharmacological-action XML (``pa{year}.xml``) to the raw layer."""
+    s = settings or get_settings()
+    return download(f"{s.mesh_xml_base}pa{year}.xml", raw_dir(_RAW, s) / f"pa{year}.xml")
+
+
+def _supplemental_record(elem: ET.Element) -> dict | None:
+    """SCR → ui, name, class, registry number, heading-mapped-to descriptors, terms."""
+    ui = _text(elem, "SupplementalRecordUI")
+    name = _text(elem, "SupplementalRecordName/String")
+    if not ui or not name:
+        return None
+    mapped: list[dict] = []
+    for hm in elem.findall("HeadingMappedToList/HeadingMappedTo"):
+        d = hm.findtext("DescriptorReferredTo/DescriptorUI")
+        if not d:
+            continue
+        q = hm.findtext("QualifierReferredTo/QualifierUI")
+        mapped.append({
+            "descriptor_ui": d.lstrip("*"),  # '*' marks the primary mapping
+            "qualifier_ui": (q.lstrip("*") if q else ""),
+            "is_primary": d.startswith("*"),
+        })
+    reg = next(
+        (c.findtext("RegistryNumberList/RegistryNumber")
+         for c in elem.findall("ConceptList/Concept") if c.get("PreferredConceptYN") == "Y"),
+        None,
+    )
+    return {
+        "supplemental_ui": ui,
+        "name": name,
+        "scr_class": elem.get("SCRClass"),
+        "registry_number": reg if reg not in ("0", "") else None,
+        "mapped_to": mapped,
+        "entry_terms": _entry_terms(elem),
+    }
+
+
+def _pharmacological_action_record(elem: ET.Element) -> dict | None:
+    """PharmacologicalAction → action descriptor UI + the substance (D/C) UIs it covers."""
+    action = elem.findtext("DescriptorReferredTo/DescriptorUI")
+    if not action:
+        return None
+    subs = [
+        s.text.strip()
+        for s in elem.findall("PharmacologicalActionSubstanceList/Substance/RecordUI")
+        if s.text
+    ]
+    return {"action_ui": action, "substances": subs}
+
+
+def supplemental_to_ndjson(xml_path: Path | str, ndjson_path: Path | str) -> int:
+    """Stream the SCR XML → NDJSON (one structured object per supplemental record)."""
+    n = _to_ndjson(Path(xml_path), Path(ndjson_path), "SupplementalRecord", _supplemental_record)
+    _log.info("parsed {:,} supplemental records → {}", n, Path(ndjson_path).name)
+    return n
+
+
+def pharmacological_actions_to_ndjson(xml_path: Path | str, ndjson_path: Path | str) -> int:
+    """Stream the pharmacological-action XML → NDJSON (one object per action)."""
+    n = _to_ndjson(
+        Path(xml_path), Path(ndjson_path), "PharmacologicalAction", _pharmacological_action_record
+    )
+    _log.info("parsed {:,} pharmacological actions → {}", n, Path(ndjson_path).name)
+    return n
+
+
+def _supplemental_sql(src: str, version: str, limit: int | None) -> str:
+    limit_sql = f" LIMIT {int(limit)}" if limit else ""
+    return f"""
+        SELECT supplemental_ui, name, scr_class, registry_number,
+               CAST('{version}' AS VARCHAR) AS snapshot_version
+        FROM read_parquet({src}){limit_sql}
+    """
+
+
+def _supplemental_descriptor_sql(src: str, version: str, limit: int | None) -> str:
+    """Explode the heading-mapped-to bridge (SCR → descriptor, with the primary flag)."""
+    limit_sql = f" LIMIT {int(limit)}" if limit else ""
+    return f"""
+        WITH d AS (SELECT supplemental_ui, mapped_to FROM read_parquet({src}){limit_sql}),
+             ex AS (SELECT supplemental_ui, unnest(mapped_to) AS m FROM d)
+        SELECT supplemental_ui, m.descriptor_ui AS descriptor_ui,
+               m.qualifier_ui AS qualifier_ui, bool_or(m.is_primary) AS is_primary,
+               CAST('{version}' AS VARCHAR) AS snapshot_version
+        FROM ex WHERE m.descriptor_ui IS NOT NULL
+        GROUP BY supplemental_ui, m.descriptor_ui, m.qualifier_ui
+    """
+
+
+def _supplemental_term_sql(src: str, version: str, limit: int | None) -> str:
+    limit_sql = f" LIMIT {int(limit)}" if limit else ""
+    return f"""
+        WITH d AS (SELECT supplemental_ui, entry_terms FROM read_parquet({src}){limit_sql}),
+             ex AS (SELECT supplemental_ui, unnest(entry_terms) AS et FROM d)
+        SELECT supplemental_ui, et.term AS term, bool_or(et.is_preferred) AS is_preferred,
+               CAST('{version}' AS VARCHAR) AS snapshot_version
+        FROM ex WHERE et.term IS NOT NULL
+        GROUP BY supplemental_ui, et.term
+    """
+
+
+def _pharmacological_action_sql(src: str, version: str) -> str:
+    return f"""
+        WITH d AS (SELECT action_ui, substances FROM read_parquet({src})),
+             ex AS (SELECT action_ui, unnest(substances) AS substance_ui FROM d)
+        SELECT DISTINCT substance_ui, action_ui,
+               CAST('{version}' AS VARCHAR) AS snapshot_version
+        FROM ex WHERE substance_ui IS NOT NULL
+    """
+
+
+def curate_supplemental(
+    con: duckdb.DuckDBPyConnection,
+    supplemental_parquet: Path | str,
+    *,
+    schema: str = "mesh",
+    version: str = "0",
+    limit: int | None = None,
+) -> dict[str, int]:
+    """Upsert ``mesh.supplemental`` + ``supplemental_descriptor`` + ``supplemental_term``.
+
+    SCRs are the specific chemicals/substances (~330k); each is **heading-mapped** to
+    one or more descriptors (the link into the tree), not placed in it. ``scr_class``:
+    1 chemical · 2 disease · 3 protocol · 4 organism.
+    """
+    s = csv_source(str(supplemental_parquet))
+    ex = ["snapshot_version"]
+    counts = {
+        "supplemental": upsert(
+            con, f"{LAKE}.{schema}.supplemental", _supplemental_sql(s, version, limit),
+            "supplemental_ui", exclude_change_cols=ex,
+        ),
+        "supplemental_descriptor": upsert(
+            con, f"{LAKE}.{schema}.supplemental_descriptor",
+            _supplemental_descriptor_sql(s, version, limit),
+            ["supplemental_ui", "descriptor_ui", "qualifier_ui"], exclude_change_cols=ex,
+        ),
+        "supplemental_term": upsert(
+            con, f"{LAKE}.{schema}.supplemental_term", _supplemental_term_sql(s, version, limit),
+            ["supplemental_ui", "term"], exclude_change_cols=ex,
+        ),
+    }
+    for table, n in counts.items():
+        _log.info("mesh.{} <- {:,} rows", table, n)
+    return counts
+
+
+def curate_pharmacological_actions(
+    con: duckdb.DuckDBPyConnection,
+    pa_parquet: Path | str,
+    *,
+    schema: str = "mesh",
+    version: str = "0",
+) -> int:
+    """Upsert ``mesh.pharmacological_action`` (substance ↔ action descriptor).
+
+    The curated cross-reference of what each drug/substance *does* — query literature
+    by mechanism/effect class (``action_ui`` is a D27 descriptor; ``substance_ui`` is a
+    descriptor or SCR).
+    """
+    n = upsert(
+        con, f"{LAKE}.{schema}.pharmacological_action",
+        _pharmacological_action_sql(csv_source(str(pa_parquet)), version),
+        ["substance_ui", "action_ui"], exclude_change_cols=["snapshot_version"],
+    )
+    _log.info("mesh.pharmacological_action <- {:,} rows", n)
+    return n
+
+
+def ingest_supplemental(
+    *,
+    year: int | None = None,
+    file: str | None = None,
+    schema: str = "mesh",
+    limit: int | None = None,
+    settings: Settings | None = None,
+) -> dict:
+    """Load the Supplementary Concept Records (Phase 2). ``file`` skips the download."""
+    s = settings or get_settings()
+    year = year or s.mesh_year
+    version = str(year)
+    con = lake_connect(s)
+    try:
+        raw = _bronze(con, file, lambda: download_supplemental(year, s),
+                      supplemental_to_ndjson, f"supp{year}", s)
+        with ops.run(con, source="mesh", target=f"{LAKE}.{schema}", version=version) as r:
+            counts = curate_supplemental(con, raw, schema=schema, version=version, limit=limit)
+            r.rows = sum(counts.values())
+    finally:
+        con.close()
+    return {**r.summary(), "schema": f"{LAKE}.{schema}", **counts}
+
+
+def ingest_pharmacological_actions(
+    *,
+    year: int | None = None,
+    file: str | None = None,
+    schema: str = "mesh",
+    settings: Settings | None = None,
+) -> dict:
+    """Load the pharmacological-action cross-reference (Phase 2). ``file`` skips download."""
+    s = settings or get_settings()
+    year = year or s.mesh_year
+    version = str(year)
+    con = lake_connect(s)
+    try:
+        raw = _bronze(con, file, lambda: download_pharmacological_actions(year, s),
+                      pharmacological_actions_to_ndjson, f"pa{year}", s)
+        with ops.run(
+            con, source="mesh", target=f"{LAKE}.{schema}.pharmacological_action", version=version
+        ) as r:
+            r.rows = curate_pharmacological_actions(con, raw, schema=schema, version=version)
+    finally:
+        con.close()
+    return {**r.summary(), "table": f"{LAKE}.{schema}.pharmacological_action"}

--- a/tests/fixtures/mesh_pa_sample.xml
+++ b/tests/fixtures/mesh_pa_sample.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PharmacologicalActionSet>
+  <PharmacologicalAction>
+    <DescriptorReferredTo>
+      <DescriptorUI>D000894</DescriptorUI>
+      <DescriptorName><String>Anti-Inflammatory Agents, Non-Steroidal</String></DescriptorName>
+    </DescriptorReferredTo>
+    <PharmacologicalActionSubstanceList>
+      <Substance>
+        <RecordUI>D001241</RecordUI>
+        <RecordName><String>Aspirin</String></RecordName>
+      </Substance>
+      <Substance>
+        <RecordUI>C000005</RecordUI>
+        <RecordName><String>rofecoxib</String></RecordName>
+      </Substance>
+    </PharmacologicalActionSubstanceList>
+  </PharmacologicalAction>
+  <PharmacologicalAction>
+    <DescriptorReferredTo>
+      <DescriptorUI>D058633</DescriptorUI>
+      <DescriptorName><String>Antipyretics</String></DescriptorName>
+    </DescriptorReferredTo>
+    <PharmacologicalActionSubstanceList>
+      <Substance>
+        <RecordUI>D001241</RecordUI>
+        <RecordName><String>Aspirin</String></RecordName>
+      </Substance>
+    </PharmacologicalActionSubstanceList>
+  </PharmacologicalAction>
+</PharmacologicalActionSet>

--- a/tests/fixtures/mesh_supp_sample.xml
+++ b/tests/fixtures/mesh_supp_sample.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SupplementalRecordSet LanguageCode="eng">
+  <SupplementalRecord SCRClass="1">
+    <SupplementalRecordUI>C000002</SupplementalRecordUI>
+    <SupplementalRecordName><String>bevonium</String></SupplementalRecordName>
+    <HeadingMappedToList>
+      <HeadingMappedTo>
+        <DescriptorReferredTo>
+          <DescriptorUI>*D001561</DescriptorUI>
+          <DescriptorName><String>Benzilates</String></DescriptorName>
+        </DescriptorReferredTo>
+      </HeadingMappedTo>
+      <HeadingMappedTo>
+        <DescriptorReferredTo>
+          <DescriptorUI>D010879</DescriptorUI>
+          <DescriptorName><String>Piperidines</String></DescriptorName>
+        </DescriptorReferredTo>
+      </HeadingMappedTo>
+    </HeadingMappedToList>
+    <ConceptList>
+      <Concept PreferredConceptYN="Y">
+        <RegistryNumberList>
+          <RegistryNumber>34B0471E08</RegistryNumber>
+        </RegistryNumberList>
+        <TermList>
+          <Term ConceptPreferredTermYN="Y"><String>bevonium</String></Term>
+          <Term ConceptPreferredTermYN="N"><String>bevonium methyl sulfate</String></Term>
+        </TermList>
+      </Concept>
+    </ConceptList>
+  </SupplementalRecord>
+  <SupplementalRecord SCRClass="1">
+    <SupplementalRecordUI>C000005</SupplementalRecordUI>
+    <SupplementalRecordName><String>rofecoxib</String></SupplementalRecordName>
+    <HeadingMappedToList>
+      <HeadingMappedTo>
+        <DescriptorReferredTo>
+          <DescriptorUI>*D052246</DescriptorUI>
+          <DescriptorName><String>Cyclooxygenase 2 Inhibitors</String></DescriptorName>
+        </DescriptorReferredTo>
+      </HeadingMappedTo>
+    </HeadingMappedToList>
+    <ConceptList>
+      <Concept PreferredConceptYN="Y">
+        <RegistryNumberList>
+          <RegistryNumber>0</RegistryNumber>
+        </RegistryNumberList>
+        <TermList>
+          <Term ConceptPreferredTermYN="Y"><String>rofecoxib</String></Term>
+          <Term ConceptPreferredTermYN="N"><String>Vioxx</String></Term>
+        </TermList>
+      </Concept>
+    </ConceptList>
+  </SupplementalRecord>
+</SupplementalRecordSet>

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -119,6 +119,65 @@ def test_mesh_article_headings_explosion(lake_settings: Settings):
         con.close()
 
 
+def test_mesh_supplemental_records(lake_settings: Settings, tmp_path: Path):
+    """Phase 2 SCRs: record + heading-mapped-to bridge (with primary flag) + terms."""
+    nd = tmp_path / "supp.ndjson.gz"
+    assert mesh.supplemental_to_ndjson(FIXTURES / "mesh_supp_sample.xml", nd) == 2
+    con = lake_connect(lake_settings)
+    try:
+        raw = mesh.materialize_raw(con, nd)
+        counts = mesh.curate_supplemental(con, raw, version="2026")
+        assert counts == {
+            "supplemental": 2,
+            "supplemental_descriptor": 3,  # bevonium→2 descriptors, rofecoxib→1
+            "supplemental_term": 4,  # two terms each
+        }
+        # SCR record: class + registry number ('0' normalized to NULL).
+        cls, reg = con.execute(
+            "SELECT scr_class, registry_number FROM lake.mesh.supplemental "
+            "WHERE supplemental_ui = 'C000002'"
+        ).fetchone()
+        assert cls == "1" and reg == "34B0471E08"
+        assert con.execute(
+            "SELECT registry_number FROM lake.mesh.supplemental WHERE supplemental_ui = 'C000005'"
+        ).fetchone()[0] is None
+        # Heading-mapped-to: '*' marks the primary descriptor, UI stripped of the '*'.
+        prim = con.execute(
+            "SELECT descriptor_ui, is_primary FROM lake.mesh.supplemental_descriptor "
+            "WHERE supplemental_ui = 'C000005'"
+        ).fetchone()
+        assert prim == ("D052246", True)
+        assert con.execute(
+            "SELECT is_primary FROM lake.mesh.supplemental_descriptor "
+            "WHERE supplemental_ui = 'C000002' AND descriptor_ui = 'D010879'"
+        ).fetchone()[0] is False
+    finally:
+        con.close()
+
+
+def test_mesh_pharmacological_actions(lake_settings: Settings, tmp_path: Path):
+    """Phase 2 PAs: substance ↔ action-descriptor edge (descriptors and SCRs as substances)."""
+    nd = tmp_path / "pa.ndjson.gz"
+    assert mesh.pharmacological_actions_to_ndjson(FIXTURES / "mesh_pa_sample.xml", nd) == 2
+    con = lake_connect(lake_settings)
+    try:
+        raw = mesh.materialize_raw(con, nd)
+        # Aspirin: 2 actions; rofecoxib: 1 action → 3 edges.
+        assert mesh.curate_pharmacological_actions(con, raw, version="2026") == 3
+        got = {
+            tuple(r) for r in con.execute(
+                "SELECT substance_ui, action_ui FROM lake.mesh.pharmacological_action"
+            ).fetchall()
+        }
+        assert got == {
+            ("D001241", "D000894"),  # Aspirin → NSAID
+            ("D001241", "D058633"),  # Aspirin → Antipyretic
+            ("C000005", "D000894"),  # rofecoxib (SCR) → NSAID
+        }
+    finally:
+        con.close()
+
+
 def test_mesh_curate_idempotent(lake_settings: Settings, tmp_path: Path):
     """A re-curate of identical data is a no-op (adds no snapshot)."""
     desc_nd = tmp_path / "desc.ndjson.gz"


### PR DESCRIPTION
Phase 2 of ADR-0010 — the drug/chemical layer. Same streaming-XML medallion pattern as Phase 1.

## What
- **`mesh.supplemental`** — Supplementary Concept Records (~330k specific chemicals/substances; `scr_class` 1 chemical/2 disease/3 protocol/4 organism; `registry_number` = UNII/CAS) from `supp{year}.gz` (~786 MB).
- **`mesh.supplemental_descriptor`** — the **heading-mapped-to** bridge: SCRs have no tree numbers, so each is mapped to descriptor(s) — the link *into* the hierarchy. `is_primary` from the `*` prefix; qualifier kept.
- **`mesh.supplemental_term`** — SCR synonyms.
- **`mesh.pharmacological_action`** — `(substance_ui, action_ui)` from `pa{year}.xml`: what each drug/substance *does*, so you can query literature by mechanism/effect (e.g. "platelet aggregation inhibitors" pulls aspirin, clopidogrel, …).

New `mesh supplemental` + `mesh actions` CLI commands; shared `_entry_terms` helper.

## Verified against live NLM files
Element paths (`SupplementalRecord SCRClass`, `HeadingMappedTo` with the `*`-major prefix, `RegistryNumber`; `PharmacologicalAction` → `Substance/RecordUI`) were confirmed against the live `pa2026.xml` and `supp2026.gz` before coding.

## Test plan
- `uv run ruff check src/ tests/` — clean
- `uv run pytest -q` — 31 passed, 3 skipped (new SCR + PA tests: heading-mapped-to primary flag, `'0'`→NULL registry normalization, the substance↔action edge)
- All 4 `mesh` CLI commands load (`run` / `headings` / `supplemental` / `actions`)

## To load (after `mesh run`)
`mesh supplemental` (~786 MB, the big one) and `mesh actions` (small).

🤖 Generated with [Claude Code](https://claude.com/claude-code)