### PR TITLE
MeSH: article_chemical edge from PubMed ChemicalList

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -88,8 +88,10 @@ cdsci-lake` and `lake_connect(read_only=True)`.
   layer) is also built:** `mesh.supplemental` (SCRs — chemicals/substances),
   `mesh.supplemental_descriptor` (SCR→descriptor heading-mapped-to bridge),
   `mesh.supplemental_term`, and `mesh.pharmacological_action` (substance↔mechanism).
-  See ADR-0010. To load: `mesh run` (vocab), `mesh headings` (literature edge),
-  `mesh supplemental` (SCRs, ~786 MB), `mesh actions` (pharm actions).
+  Plus `mesh.article_chemical` (pmid↔substance from PubMed ChemicalList) —
+  completing article → substance → `pharmacological_action` → mechanism. See
+  ADR-0010. To load: `mesh run` (vocab), `mesh headings` + `mesh chemicals`
+  (literature edges), `mesh supplemental` (SCRs, ~786 MB), `mesh actions`.
 - **MERGE-upsert** (`cdsci.lake.upsert`, ADR-0003) — keyed, change-detecting (updates
   only on real diffs), idempotent (no-op re-run adds no snapshot) → meaningful
   time-travel. Per-load stamps (`snapshot_version`) are excluded from change-detection

--- a/docs/adr/0010-mesh-vocabulary.md
+++ b/docs/adr/0010-mesh-vocabulary.md
@@ -81,9 +81,13 @@ annual cadence; `us-public-domain` / NLM). Two phases.
 - `mesh.supplemental_term` — SCR synonyms.
 - `mesh.pharmacological_action` — `(substance_ui, action_ui)`, what each
   drug/substance *does* (query literature by mechanism/effect), from `pa{year}.xml`.
+- `mesh.article_chemical` — `(pmid, substance_ui)` from
+  `omicidx.pubmed_article.chemical_list` (UIs are `D…` descriptor-chemicals or `C…`
+  SCRs). The chemical analogue of `article_heading`; completes **article → substance
+  → `pharmacological_action` → mechanism** and article → substance →
+  `supplemental_descriptor` → descriptor → tree.
 
-Still later: see-also cross-refs; a PubMed `ChemicalList` → SCR article edge (the
-chemical analogue of `article_heading`).
+Still later: see-also cross-refs; the major-topic flag.
 
 **No `mesh ↔ openalex_topic` crosswalk** — researched, and **no canonical mapping
 exists**: an OpenAlex Topic exposes only an OpenAlex id + a single Wikipedia URL (no

--- a/src/cdsci/lake/sources/mesh/__init__.py
+++ b/src/cdsci/lake/sources/mesh/__init__.py
@@ -22,16 +22,21 @@ Phase 2 adds the drug/chemical layer: ``mesh.supplemental`` (SCRs — specific
 chemicals/substances, ``scr_class`` 1 chemical/2 disease/3 protocol/4 organism),
 ``mesh.supplemental_descriptor`` (the heading-mapped-to bridge SCR→descriptor, with
 ``is_primary``), ``mesh.supplemental_term`` (SCR synonyms), and
-``mesh.pharmacological_action`` (substance ↔ mechanism/effect descriptor).
+``mesh.pharmacological_action`` (substance ↔ mechanism/effect descriptor). The
+chemical literature edge ``mesh.article_chemical`` — ``(pmid, substance_ui)`` from
+``omicidx.pubmed_article.chemical_list`` — completes article → substance →
+``pharmacological_action`` → mechanism (the analogue of ``article_heading``).
 """
 
 from .ingest import (
     curate,
+    curate_article_chemicals,
     curate_article_headings,
     curate_pharmacological_actions,
     curate_supplemental,
     descriptors_to_ndjson,
     ingest,
+    ingest_chemicals,
     ingest_headings,
     ingest_pharmacological_actions,
     ingest_supplemental,
@@ -43,11 +48,13 @@ from .ingest import (
 
 __all__ = [
     "curate",
+    "curate_article_chemicals",
     "curate_article_headings",
     "curate_pharmacological_actions",
     "curate_supplemental",
     "descriptors_to_ndjson",
     "ingest",
+    "ingest_chemicals",
     "ingest_headings",
     "ingest_pharmacological_actions",
     "ingest_supplemental",

--- a/src/cdsci/lake/sources/mesh/__main__.py
+++ b/src/cdsci/lake/sources/mesh/__main__.py
@@ -7,6 +7,7 @@ import typer
 from ...log import configure
 from .ingest import (
     ingest,
+    ingest_chemicals,
     ingest_headings,
     ingest_pharmacological_actions,
     ingest_supplemental,
@@ -61,6 +62,23 @@ def headings(
 ) -> None:
     """Build mesh.article_heading (pmid↔descriptor↔qualifier) from omicidx PubMed MeSH."""
     s = ingest_headings(version=version, source_table=source_table, schema=schema, limit=limit)
+    delta = "changed" if s["changed"] else "no change (idempotent)"
+    typer.echo(f"{s['table']} <- {s['rows']:,} rows — {delta}")
+
+
+@app.command("chemicals")
+def chemicals(
+    version: str | None = typer.Option(
+        None, "--version", help="Snapshot label (default: YYYY-MM)."
+    ),
+    source_table: str = typer.Option(
+        "lake.omicidx.pubmed_article", "--source-table", help="In-lake PubMed source."
+    ),
+    schema: str = typer.Option("mesh", "--schema", help="Target lake schema."),
+    limit: int | None = typer.Option(None, "--limit", help="Cap source articles (smoke test)."),
+) -> None:
+    """Build mesh.article_chemical (pmid↔substance) from omicidx PubMed ChemicalList."""
+    s = ingest_chemicals(version=version, source_table=source_table, schema=schema, limit=limit)
     delta = "changed" if s["changed"] else "no change (idempotent)"
     typer.echo(f"{s['table']} <- {s['rows']:,} rows — {delta}")
 

--- a/src/cdsci/lake/sources/mesh/ingest.py
+++ b/src/cdsci/lake/sources/mesh/ingest.py
@@ -620,3 +620,84 @@ def ingest_pharmacological_actions(
     finally:
         con.close()
     return {**r.summary(), "table": f"{LAKE}.{schema}.pharmacological_action"}
+
+
+# --- Literature edge: PubMed ChemicalList → substance (descriptor or SCR) ---
+
+
+def _article_chemical_sql(source_table: str, version: str, limit: int | None) -> str:
+    """Explode ``chemical_list`` (``UI:Name; …``) → (pmid, substance_ui).
+
+    ``substance_ui`` is a ``D…`` descriptor-chemical or a ``C…`` SCR — it joins
+    ``mesh.descriptor``/``mesh.supplemental`` for the substance and, crucially,
+    ``mesh.pharmacological_action`` to reach the drug's mechanism/effect classes.
+    No qualifiers in this field, so the key ``(pmid, substance_ui)`` needs no
+    sentinel. ``limit`` caps source rows.
+    """
+    limit_sql = f" LIMIT {int(limit)}" if limit else ""
+    return rf"""
+        WITH src AS (
+            SELECT TRY_CAST(pmid AS BIGINT) AS pmid, chemical_list
+            FROM {source_table}
+            WHERE chemical_list IS NOT NULL AND chemical_list <> ''{limit_sql}
+        ),
+        items AS (
+            SELECT pmid, trim(c) AS item
+            FROM src, unnest(string_split(chemical_list, ';')) AS t(c)
+            WHERE trim(c) <> ''
+        )
+        SELECT DISTINCT pmid, regexp_extract(item, '^([CD]\d+)', 1) AS substance_ui,
+               CAST('{version}' AS VARCHAR) AS snapshot_version
+        FROM items
+        WHERE pmid IS NOT NULL AND regexp_extract(item, '^([CD]\d+)', 1) <> ''
+    """
+
+
+def curate_article_chemicals(
+    con: duckdb.DuckDBPyConnection,
+    *,
+    schema: str = "mesh",
+    version: str = "0",
+    source_table: str = _PUBMED,
+    limit: int | None = None,
+) -> int:
+    """Upsert ``mesh.article_chemical`` (pmid ↔ substance) from PubMed's ChemicalList.
+
+    The chemical analogue of :func:`curate_article_headings`: completes
+    article → substance → ``pharmacological_action`` → mechanism, and article →
+    substance → ``supplemental_descriptor`` → descriptor → tree. Large (one row per
+    article × chemical); the MERGE re-reads the target, so a full rebuild is heavy.
+    """
+    n = upsert(
+        con,
+        f"{LAKE}.{schema}.article_chemical",
+        _article_chemical_sql(source_table, version, limit),
+        ["pmid", "substance_ui"],
+        exclude_change_cols=["snapshot_version"],
+    )
+    _log.info("mesh.article_chemical <- {:,} rows", n)
+    return n
+
+
+def ingest_chemicals(
+    *,
+    schema: str = "mesh",
+    version: str | None = None,
+    source_table: str = _PUBMED,
+    limit: int | None = None,
+    settings: Settings | None = None,
+) -> dict:
+    """Build ``mesh.article_chemical`` from omicidx PubMed ChemicalList. No download."""
+    s = settings or get_settings()
+    version = version or _today_version()
+    con = lake_connect(s)
+    try:
+        with ops.run(
+            con, source="mesh", target=f"{LAKE}.{schema}.article_chemical", version=version
+        ) as r:
+            r.rows = curate_article_chemicals(
+                con, schema=schema, version=version, source_table=source_table, limit=limit
+            )
+    finally:
+        con.close()
+    return {**r.summary(), "table": f"{LAKE}.{schema}.article_chemical"}

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -119,6 +119,39 @@ def test_mesh_article_headings_explosion(lake_settings: Settings):
         con.close()
 
 
+def test_mesh_article_chemicals_explosion(lake_settings: Settings):
+    """Literature edge: explode omicidx chemical_list → (pmid, substance_ui)."""
+    con = lake_connect(lake_settings)
+    try:
+        con.execute("CREATE SCHEMA lake.omicidx;")
+        con.execute(
+            "CREATE TABLE lake.omicidx.pubmed_article AS SELECT * FROM (VALUES "
+            "('1', 'D011494:Protein Kinases; D000098984:Fluorescent Cmpd; C000005:rofecoxib'), "
+            "('2', 'D017382:Reactive Oxygen Species'), "
+            "('3', NULL)) t(pmid, chemical_list);"
+        )
+        n = mesh.curate_article_chemicals(con, version="2026-06")
+        assert n == 4  # pmid1: 3 substances ; pmid2: 1 ; pmid3 skipped
+        got = {
+            tuple(r) for r in con.execute(
+                "SELECT pmid, substance_ui FROM lake.mesh.article_chemical"
+            ).fetchall()
+        }
+        assert got == {
+            (1, "D011494"),
+            (1, "D000098984"),  # long (9-digit) descriptor UI
+            (1, "C000005"),  # an SCR substance
+            (2, "D017382"),
+        }
+        # pmid is BIGINT; idempotent re-run adds no snapshot.
+        before = con.execute("SELECT max(snapshot_id) FROM lake.snapshots()").fetchone()[0]
+        mesh.curate_article_chemicals(con, version="2026-06")
+        after = con.execute("SELECT max(snapshot_id) FROM lake.snapshots()").fetchone()[0]
+        assert after == before
+    finally:
+        con.close()
+
+
 def test_mesh_supplemental_records(lake_settings: Settings, tmp_path: Path):
     """Phase 2 SCRs: record + heading-mapped-to bridge (with primary flag) + terms."""
     nd = tmp_path / "supp.ndjson.gz"


### PR DESCRIPTION
The chemical analogue of `article_heading`, completing the drug/chemical loop.

## What
- **`mesh.article_chemical (pmid, substance_ui)`** — exploded from `omicidx.pubmed_article.chemical_list` (UIs are `D…` descriptor-chemicals or `C…` SCRs).
- This closes the chain: **article → substance → `pharmacological_action` → mechanism/effect**, and article → substance → `supplemental_descriptor` → descriptor → tree. So you can now ask "papers on anti-inflammatory *mechanisms*" and get every article mentioning any substance with that pharmacological action.
- New `curate_article_chemicals` / `ingest_chemicals` + a `mesh chemicals` CLI command.

## Verified
Explosion SQL checked against the real `chemical_list` format (`D011494:Protein Kinases; D000098984:…; C000005:rofecoxib`) — multi-substance split, 9-digit descriptor UIs, SCR C-UIs all parse; NULL skipped.

## Test plan
- `uv run ruff check src/ tests/` — clean
- `uv run pytest -q` — 32 passed, 3 skipped (new `test_mesh_article_chemicals_explosion`)
- `mesh chemicals` CLI command loads

## Scale / load
Large (article × chemical); MERGE re-reads the target. Build with `mesh chemicals` after `mesh run`/`mesh supplemental`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)