### PR TITLE
feat: multi-producer write contract (ADR-0011/0012/0013)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,90 @@
+# cdsci-lake
+
+The shared research-data lake platform: the DuckLake **substrate** (one catalog +
+write library + snapshot contract) that many independent producers write into and
+many consumers read from. This glossary pins the terms the platform's contract
+depends on; decisions live in `docs/adr/`.
+
+## Roles
+
+**Producer**:
+A codebase that writes curated tables into the lake (this repo's ingestors,
+omicidx, later scp/cmgd). Each owns its schema(s), extract, and transform, and
+writes through the shared contract (ADR-0011).
+_Also_: Publisher (ADR-0001's term for the same thing).
+
+**Consumer**:
+A codebase that only reads the lake (`read_only=True`) — a dashboard, API, or
+project. Never mutates the substrate; assumes the data exists.
+
+**Writer**:
+The producer identity stamped on every write — the `writer` field of a registered
+`Source` and the `author = "<writer>:<source>"` prefix on the snapshot it produces
+(`cdsci`, `omicidx`). Distinguishes producers in the one shared ledger and catalog.
+
+**Substrate**:
+The shared, producer-agnostic core: `lake_connect`, the write verbs, and the `ops`
+ledger. Has no dependency on any producer's ingestors; the dependency arrow points
+*into* it.
+
+## Write vocabulary
+
+**Source**:
+A registered upstream dataset (`icite`, `reporter`, `sra`, `geo`) that owns a lake
+schema and refreshes on a cadence. Declared in producer code, materialised into
+`lake_ops.source` via `register_sources`.
+
+**upsert**:
+The default write: a keyed MERGE that INSERTs new rows and UPDATEs only where a
+non-key column actually differs (`IS DISTINCT FROM`), so an unchanged re-run writes
+nothing and adds no snapshot (ADR-0003). No content-hash column — the compare set
+is derived from the source projection.
+_Avoid_: merge, load (when you mean this specific keyed MERGE).
+
+**rebuild**:
+A full-replace (CREATE OR REPLACE) write for recomputed derived tables. **Not part
+of the EL write path** — derived tables are transform-layer artifacts and defer
+with the transform layer (ADR-0013). Named here only so the term is fixed for when
+that layer lands; today the EL contract has one verb, `upsert`.
+_Avoid_: replace, truncate-and-load, refresh.
+
+## Operational ledger (`lake_ops`)
+
+**Ledger**:
+Catalog-adjacent native state (the `ops` attachment: Postgres in production, a
+sibling `ops.duckdb` locally) — **not** DuckLake data. Answers the questions
+snapshots can't: when/whether/where a run happened (ADR-0006).
+_Avoid_: metadata store (too broad), event log.
+
+**Run**:
+One recorded ingest invocation — a `lake_ops.run` row with status
+(`running`/`success`/`idempotent`/`error`), the before/after snapshot ids, row
+count, and version. Bracketed by the `ops.run(...)` context manager.
+
+**Watermark**:
+A mutable incremental **resume cursor**, keyed `(source, name)`, one value per
+source (e.g. OpenAlex `updated_date`, SRA's high-water partition). In-place UPDATE
+in the ledger.
+_Not_: crawl state — a producer's per-partition "did I extract this key yet"
+done-set (omicidx's raw-extract semaphore files) is thousands of keys, a different
+lifecycle, and stays producer-local; the watermark is a single cursor (ADR-0011 §3).
+
+**Snapshot attribution**:
+The self-describing commit metadata a write stamps on the DuckLake snapshot it
+produces — `author = "<writer>:<source>"` plus a canonical `commit_extra_info` JSON
+(`writer, source, target, version, run_id, op`, + optional producer extras). Lets
+one query attribute any snapshot without a ledger join (ADR-0008, ADR-0011 §5).
+
+## Data layers
+
+**Bronze**:
+Raw upstream downloads (on R2/local), kept verbatim and unregistered, so a
+re-curate needs no re-download (ADR-0012).
+
+**Silver**:
+The per-source curated, typed tables exposed via versioned views — the consumer
+contract (ADR-0001 §3).
+
+**Gold**:
+Cohorts, entity resolution, cross-source analytics. Stays in **consumer** projects,
+never in a source schema or the lake.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -31,6 +31,22 @@ rationale for *what's next*, not how it was built.
 - ~~**Repo remote**~~ — **done**: private GitHub repo `seandavi/cdsci-lake`, `main`
   pushed.
 
+## Transform layer (deferred — ADR-0012/0013)
+
+The EL write path is `upsert`-only; derived tables and transforms (incl.
+sqlmesh-based) are deferred. When the transform layer lands it must also:
+
+- **Capture transform runs/outputs.** A transform is just another *writer* to the
+  lake, so it reuses the `ops.run` / `writer` / snapshot-attribution model — no new
+  ledger, extend the existing one to record transform runs and the tables they
+  produce.
+- **Capture lineage** (net-new). The ledger records runs + snapshots, not
+  table/column dependency edges. sqlmesh computes these (column-level via SQLGlot
+  for SQL models, table-level for Python models); design where that graph is
+  captured so observability/consumers can read it alongside `ops`.
+
+Iterate the design in an issue; promote to an ADR when it stabilises.
+
 ## OpenAlex follow-ups (ADR-0005)
 
 - Watermark incrementals once `lake_ops` lands.

--- a/docs/adr/0011-multi-producer-write-contract.md
+++ b/docs/adr/0011-multi-producer-write-contract.md
@@ -1,0 +1,154 @@
+# 0011. The multi-producer write contract: omicidx converges onto `lake_connect`/`upsert`/`ops`
+
+- Status: accepted
+- Date: 2026-07-10
+
+> Turns the "omicidx and this repo are peer publishers" premise of ADR-0001 §1
+> (restated in ADR-0007, ADR-0008) into a shared **write contract**. omicidx stops
+> hand-rolling its DuckLake writes and imports this library's write path. Settled in
+> a grilling session; the deliberation is preserved as the seven decisions below.
+
+## Context
+
+Two live publishers write the one shared catalog (Postgres `lake` + R2
+`cdsci-lake`): this repo's ingestors and omicidx. They evolved **parallel,
+divergent write paths** for the same job:
+
+| Concern | cdsci.lake | omicidx (pre-convergence) |
+|---|---|---|
+| change gate | `upsert` — `IS DISTINCT FROM` over auto-derived columns | `merge_to_ducklake` — `_row_hash` column the projection hand-computes |
+| run/watermark state | `ops.run` / `ops.watermark` (catalog-adjacent ledger, ADR-0006) | `HighWaterMark` + `SemaphoreStore` (JSON files in the bucket) |
+| snapshot attribution | `author="cdsci:<source>"` + canonical JSON (ADR-0008) | `author="prefect:ducklake-load"` + a different JSON |
+| connection | `lake_connect` (GSM creds, no secret-dir isolation) | `get_ducklake_connection` (env creds, isolates `secret_directory`) |
+
+The costs are concrete: the `_row_hash` path carries a **double-list drift hazard**
+(projected columns vs the columns hashed inside `md5(to_json({...}))` can diverge →
+silent MERGE update-miss); the two attribution shapes defeat ADR-0008's "one query
+attributes any snapshot"; and the connection code is duplicated and **already
+drifted** (omicidx has a `secret_directory` fix this repo's path lacks). This is the
+"parallel copy" tax — every fix and convention must be applied twice.
+
+Publishing omicidx reproducibly (omicidx ADR-0004) runs *through* this library, so
+the write path can't stay a private divergent copy. omicidx is therefore the
+**second write-side adapter** that turns this library's write path from a
+hypothetical seam into a proven one.
+
+## Decision
+
+omicidx takes a dependency on `cdsci-lake` (base install — the write path has no
+dependency on the `[ingest]` ingestors) and deletes its parallel write code. Seven
+points settle the contract:
+
+1. **Depend, don't fork.** omicidx imports `lake_connect` / `upsert` / `ops`; it
+   deletes `get_ducklake_connection`, `merge_to_ducklake`, `replace_to_ducklake`,
+   and `HighWaterMark`. Extracting this repo's *ingestors* into their own package
+   (leaving a `cdsci-lake-core` substrate) is **deferred** — the base install
+   already gives the substrate/producer split logically; carve it only when a
+   second core-only consumer exists.
+
+2. **`IS DISTINCT FROM`, no hash.** All keyed writes go through `upsert`; the
+   `_row_hash` columns are **dropped** from omicidx's projections and stored tables
+   (a one-time `ALTER … DROP COLUMN`/rebuild). `upsert` derives the compare-column
+   set from `DESCRIBE`, so the ergonomic reason for a digest is gone and the
+   drift hazard is deleted, not merely excluded.
+
+3. **State splits by job.** omicidx's semaphore files were doing two jobs. Raw-
+   extract **crawl gating** (per-partition done-set, thousands of keys — a shape
+   this repo's bulk-dump sources never have) **stays in semaphore files**. The
+   lake-load **watermark + run-recording** move onto `ops.watermark` / `ops.run`.
+   `ops` is not Postgres-locked — the `local` backend gives a portable sibling
+   `ops.duckdb`, so local/published reproducibility keeps a file-based ledger for
+   free; omicidx *gains* the run history (`last loaded / changed / errored / which
+   snapshot`) it never persisted.
+
+4. **Producers register their own sources.** The `SOURCES` tuple stops being the
+   only registry. `bootstrap` ensures the `lake_ops` **schema only** — it seeds
+   nothing. Registration happens through a new **`ops.register_sources(con, *,
+   writer, sources)`**, and `_attach_ops`/`lake_connect` must **never** call it (a
+   substrate that force-registered on connect would let a foreign producer re-seed
+   another's rows on every connect). Two registration paths, by producer kind:
+   - **External producers** (omicidx) call `register_sources(writer="omicidx", …)`
+     explicitly, once at their load entrypoint (the top of `ducklake_load_flow`;
+     idempotent, self-healing) — their source list lives in their repo.
+   - **The library's built-in sources** (cdsci's `SOURCES`, which already lives in
+     `ops.py`) **self-register lazily inside `ops.run`**: on run entry, a source
+     that matches `SOURCES` and isn't yet in `lake_ops.source` is registered with
+     its own `writer`. cdsci has 11 entrypoint-less ingestor CLIs that all route
+     through `ops.run(source=…)`, so this gives them correct attribution with no
+     per-ingestor call — and a foreign `run(source="sra")` (not in `SOURCES`) touches
+     no cdsci rows. (When the ingestors are eventually split out of the substrate,
+     `SOURCES` moves with them and this self-register becomes an explicit call like
+     any other producer's.)
+
+   A **`writer`** field is added to `Source` / `lake_ops.source` so the shared
+   ledger is per-producer queryable (`cdsci`, `omicidx`); the `register_sources`
+   `writer` param is authoritative for the row (the `Source.writer` field is a
+   default). The dependency arrow stays correct — omicidx's source list lives in
+   omicidx.
+
+5. **One attribution shape.** `ops.Run` carries `writer`; the snapshot `author`
+   becomes `f"{writer}:{source}"` (`omicidx:sra`, `cdsci:icite`) instead of a
+   hardcoded `cdsci:`. `commit_extra_info` standardises on the canonical keys
+   (`writer, source, target, version, run_id, op`) plus an optional per-producer
+   **`extra`** dict merged in — omicidx keeps `prefect_run_id` for the snapshot→
+   Prefect-run link. This completes the reconciliation ADR-0008 deferred.
+
+6. **One connection, pluggable credentials.** `lake_connect` becomes the single
+   connection builder; its **credential source is pluggable** (GSM for this repo's
+   `gcloud` context, env for omicidx's Prefect workers). Two real credential
+   backends = a real seam. omicidx's `secret_directory` isolation is **ported into
+   `lake_connect`**, fixing this repo's latent "ambiguous `pg_main` secret" /
+   "unknown storage `local_file`" exposure. Attach mechanics, secret hygiene, and
+   HTTP-retry tuning now live once.
+
+7. **One write verb — `upsert` (refined by ADR-0013).** The contract sanctions a
+   single write verb. Every EL table is a keyed projection of a raw source, so
+   `upsert` covers them all (delta snapshots even for full dumps). A `rebuild` /
+   CREATE-OR-REPLACE primitive is **not** added: the only thing that would need it —
+   derived tables — is a transform-layer artifact, deferred with the transform
+   layer (ADR-0012, ADR-0013). No `truncate` either. (Phase-1 scoping refined this
+   §7; the original proposal added a second `rebuild` verb.)
+
+## Consequences
+
+- The double-list `_row_hash` drift hazard is **gone from the codebase**, not
+  worked around. One MERGE implementation, one attribution shape, one connection
+  builder across both publishers.
+- The shared `lake_ops` ledger and catalog attribution are now **multi-producer
+  aware** (`writer` on `source`, `writer`-prefixed snapshot `author`); "show me all
+  omicidx loads / whose snapshot is this" is one query, feeding the cross-producer
+  observability goal.
+- omicidx becomes the **reference producer**: the seam it validates and the `writer`
+  registration + env-cred path it exercises are the spec the next producer (scp,
+  cmgd) copies.
+- **New surface here:** `Run.writer`, `run(extra=)`, `register_sources`,
+  `bootstrap` no longer seeds sources (external producers call `register_sources`;
+  built-in `SOURCES` self-register lazily via `ops.run` — see §4), a `writer`
+  column on `lake_ops.source`, and a pluggable cred source + `secret_directory`
+  isolation in `lake_connect`. (No `rebuild` primitive — see §7 / ADR-0013.)
+- **Resolved (Phase-1):** omicidx's derived `linkage` table is a *transform-layer*
+  artifact, not EL — it stays parked and un-wired until the transform layer lands
+  (ADR-0013), not wired into the lake load. The "gold stays in consumers" boundary
+  (ADR-0001 §3) never had to be invoked: it's a crosswalk built by a transform, and
+  transforms are deferred.
+- **Reversible cost:** omicidx's env-cred branch and the `writer` column are cheap
+  to carry; if the ingestor-extraction (decision 1, deferred) later happens, the
+  contract surface (`lake_connect`/`upsert`/`ops`) is exactly what moves into
+  `cdsci-lake-core` unchanged.
+
+## Alternatives considered
+
+- **Share conventions only** (ADRs + a JSON shape, no code dependency). Rejected:
+  leaves the `_row_hash` bug and two machineries alive; the publication story stays
+  "trust two implementations agree."
+- **Carve `cdsci-lake-core` now.** Rejected as premature — one importer is a
+  hypothetical seam; the base install already separates substrate from ingestors.
+- **Move all state (incl. the raw crawl) onto `ops`.** Rejected: `ops.watermark` is
+  one cursor per `(source, name)`, not a done-set of thousands of partition keys;
+  it would reinvent the semaphore inside Postgres.
+- **A second `rebuild` verb for derived tables.** Initially accepted (§7), then
+  refined away in Phase-1 scoping (ADR-0013): derived tables are transform-layer
+  artifacts, so the EL contract never faces the keyless-recompute case and stays
+  `upsert`-only.
+- **Add a `truncate` primitive.** Rejected: it's a sanctioned footgun, and the case
+  it targets (a schema reset) belongs to a transform-layer rebuild, not the EL path.

--- a/docs/adr/0012-defer-gateway-config-file.md
+++ b/docs/adr/0012-defer-gateway-config-file.md
@@ -1,0 +1,62 @@
+# 0012. Defer the gateway / config-file target model
+
+- Status: accepted
+- Date: 2026-07-10
+
+> A defer-with-triggers decision in the shape of ADR-0007. Records *why* the lake
+> keeps env-based, two-target config for now and the exact conditions under which a
+> gateway/config-file model becomes worth it.
+
+## Context
+
+The write contract (ADR-0011 §6) selects a connection target via
+`lake_backend: "local" | "postgres"` — env-driven pydantic-settings, with a
+pluggable credential source. A richer alternative was raised: a sqlmesh-style
+**gateway** config file, where named targets (`local`, `shared`, later
+`frozen-<producer>`) each declare a backend + credentials, selectable per run.
+
+Two clarifications shaped the decision:
+
+- **Portability is already delivered without it.** The `local` backend (file
+  catalog + local-fs data) plus the portable sibling `ops.duckdb` (ADR-0011 §3) let
+  a published producer run end-to-end locally today. A config file adds *no*
+  portability — only multi-target ergonomics and the option to share one connection
+  definition with sqlmesh.
+- **The real prize is config-sharing with sqlmesh, and it isn't bankable yet.**
+  sqlmesh is a *potential* transform layer, not a chosen one. Building a config
+  format that mirrors sqlmesh's gateway schema before sqlmesh is adopted bets on an
+  untaken tool; the de-duplication only pays off once sqlmesh is real and both the
+  EL (`lake_connect`) and the T (sqlmesh) read the same file.
+
+## Decision
+
+**Keep env + `lake_backend` as the two-target seed. Do not build a gateway /
+config-file model now.** `lake_backend` already *is* a named-target selector;
+adding a third target later is one enum value + branch, and moving to a file is a
+serialization change, not a re-architecture. No structure is being deferred, only a
+file format.
+
+Adopt the gateway/config-file model at the **first of**:
+
+1. a **frozen-snapshot target** appears — the federation read-path, where one
+   producer reads another's pinned published snapshot as an external model (a third
+   target the two-value enum stops expressing cleanly); or
+2. **sqlmesh is adopted** for a producer's transforms — at which point define the
+   lake connection **once** in the file sqlmesh reads, shared with `lake_connect`,
+   rather than twice.
+
+**Constraint until then:** do not mirror sqlmesh's config schema speculatively. If
+sqlmesh is adopted, share its file; if it isn't, a small platform-owned profiles
+file is the fallback — decided at trigger time, not now.
+
+## Consequences
+
+- Config shape stays orthogonal to the write contract; ADR-0011's "pluggable cred
+  source" is the only seam that must survive, and a file is just one expression of
+  it.
+- When a trigger fires, the migration is mechanical: enumerate the existing targets
+  into the file, point `lake_connect` at the selected profile. Rename
+  `lake_backend` → target/gateway vocabulary at that time.
+- Risk accepted: two producers each carry a few env vars for the `shared` target in
+  the interim. Cheap, and exactly the duplication the file would remove once it
+  earns its place.

--- a/docs/adr/0013-lake-write-path-is-el-only.md
+++ b/docs/adr/0013-lake-write-path-is-el-only.md
@@ -1,0 +1,46 @@
+# 0013. The lake write path is EL-only: `upsert`-only, derived tables defer to the transform layer
+
+- Status: accepted
+- Date: 2026-07-10
+
+> Refines ADR-0011 §7, from a Phase-1 scoping grill of omicidx's migration.
+
+## Context
+
+ADR-0011 §7 sanctioned two write verbs — `upsert` and `rebuild` — the latter for
+keyless / fully-recomputed derived tables. Scoping omicidx's migration surfaced a
+cleaner boundary:
+
+- A derived table (omicidx's `publication_accession_linkage` — a cross-entity
+  pmid↔accession inversion unioning `sra_study` + `geo_series` + `bioproject`) is a
+  **transform-layer artifact**, and the transform layer (SQLMesh / T) is
+  deliberately deferred (ADR-0012).
+- Every genuine **EL** table is a keyed projection of a *raw source* and writes
+  cleanly via `upsert` — delta snapshots even for a full external dump
+  (`sra_accessions` on `accession`).
+- So once derived tables move to the transform layer, **no EL table needs
+  `rebuild`**. The only justification for the second verb evaporates.
+
+## Decision
+
+**The lake write path (EL) is `upsert`-only.** A table earns a place on it only if
+it is a keyed projection of a raw source. Anything computed *across* tables —
+inversions, unions, aggregations, cross-source crosswalks — is a **transform-layer
+artifact** and defers with the transform layer (ADR-0012).
+
+`rebuild` and `truncate` are **not** part of the EL contract. `rebuild` becomes a
+transform-layer concern, specified if/when that layer lands. The rule for producers
+is one line: **lightest possible touch into the lake — raw → curated entity tables,
+nothing more.**
+
+## Consequences
+
+- One write verb (`upsert`). No `rebuild` / `truncate` footguns; the smallest
+  contract surface.
+- omicidx's orphaned derived loaders (`publication_accession_linkage`,
+  `geo_series_with_rnaseq_counts`) stay **parked and un-wired**, awaiting the
+  transform layer; `sra_accessions` stays in EL as `upsert`-on-`accession`.
+- Producers get a bright EL/T line — the same split the federated-producer model
+  already assumes (each producer's transform is its own, optional, deferred concern).
+- When the transform layer is chosen (ADR-0012's triggers), it owns `rebuild` and
+  the derived tables, and the parked loaders migrate there.

--- a/src/cdsci/lake/config.py
+++ b/src/cdsci/lake/config.py
@@ -61,6 +61,16 @@ class Settings(BaseSettings):
     # Catalog is the Postgres ``lake`` DB; data is the R2 bucket recorded in the
     # catalog (data path inherited on ATTACH, not re-specified). All secrets come
     # from Google Secret Manager — see :mod:`cri.secrets`.
+    # Credential source for the postgres backend (ADR-0011 §6): "gsm" reads R2 +
+    # Postgres password from Google Secret Manager (this repo's gcloud context);
+    # "env" reads them from the env-backed fields below (omicidx's Prefect workers,
+    # which have no gcloud). Two real backends = a real seam.
+    cred_source: str = "gsm"
+    # Env-backed credentials (used only when cred_source="env"); GSM path ignores
+    # these and reads the *_secret names below instead.
+    r2_account_id: str | None = None
+    lake_pg_password: str | None = None
+
     gsm_project: str = "cdsci-infra"
     lake_pg_host: str = "100.74.53.55"
     lake_pg_port: int = 5432

--- a/src/cdsci/lake/config.py
+++ b/src/cdsci/lake/config.py
@@ -10,6 +10,7 @@ and adds lake- and source-specific settings. This module has **no dependency on
 from __future__ import annotations
 
 from functools import lru_cache
+from typing import Literal
 
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -65,7 +66,7 @@ class Settings(BaseSettings):
     # Postgres password from Google Secret Manager (this repo's gcloud context);
     # "env" reads them from the env-backed fields below (omicidx's Prefect workers,
     # which have no gcloud). Two real backends = a real seam.
-    cred_source: str = "gsm"
+    cred_source: Literal["gsm", "env"] = "gsm"
     # Env-backed credentials (used only when cred_source="env"); GSM path ignores
     # these and reads the *_secret names below instead.
     r2_account_id: str | None = None

--- a/src/cdsci/lake/connect.py
+++ b/src/cdsci/lake/connect.py
@@ -14,6 +14,7 @@ lock-in risk of a young format low.
 from __future__ import annotations
 
 import os
+import tempfile
 from contextlib import nullcontext
 from pathlib import Path
 from urllib.parse import urlparse
@@ -99,7 +100,14 @@ def lake_connect(
     never mutate the shared substrate).
     """
     s = settings or get_settings()
-    con = duckdb.connect()
+    # Isolate DuckDB's secret store to an app-owned dir (ADR-0011 §6). The flow only
+    # creates TEMPORARY secrets, so this stays empty — which sidesteps a stale
+    # persistent `pg_main` secret in the default `~/.duckdb/stored_secrets` causing
+    # ATTACH failures: "Ambiguity detected for secret name 'pg_main'" (temp +
+    # persistent) and "Unknown secret storage found: 'local_file'".
+    secret_dir = os.path.join(tempfile.gettempdir(), "cdsci-lake-duckdb-secrets")
+    os.makedirs(secret_dir, exist_ok=True)
+    con = duckdb.connect(config={"secret_directory": secret_dir})
     con.execute("INSTALL httpfs; LOAD httpfs;")
     con.execute("INSTALL ducklake; LOAD ducklake;")
     _apply_limits(con, s)
@@ -163,17 +171,34 @@ def _attach_postgres(con: duckdb.DuckDBPyConnection, s: Settings, *, read_only: 
     The data path is inherited from the catalog (not re-specified). Postgres auth
     goes through ``PGPASSWORD`` so the password never lands in the ATTACH string
     or DuckDB error text; the R2 credentials become a DuckDB ``r2`` secret.
+
+    Credentials come from GSM (default) or the env-backed settings when
+    ``cred_source == "env"`` (ADR-0011 §6 — omicidx's Prefect workers have no
+    gcloud). The GSM path is byte-for-byte unchanged.
     """
     con.execute("INSTALL postgres; LOAD postgres;")
+    if s.cred_source == "env":
+        r2_key, r2_secret, r2_account, pg_password = (
+            s.r2_access_key_id, s.r2_secret_access_key, s.r2_account_id, s.lake_pg_password,
+        )
+        missing = [
+            n for n, v in (
+                ("r2_access_key_id", r2_key), ("r2_secret_access_key", r2_secret),
+                ("r2_account_id", r2_account), ("lake_pg_password", pg_password),
+            ) if not v
+        ]
+        if missing:
+            raise ValueError(f"cred_source='env' but these settings are unset: {missing}")
+    else:
+        r2_key = get_secret(s.r2_access_key_secret, s.gsm_project)
+        r2_secret = get_secret(s.r2_secret_key_secret, s.gsm_project)
+        r2_account = get_secret(s.r2_account_id_secret, s.gsm_project)
+        pg_password = get_secret(s.lake_pg_password_secret, s.gsm_project)
     con.execute(
         "CREATE OR REPLACE SECRET r2_lake (TYPE r2, KEY_ID ?, SECRET ?, ACCOUNT_ID ?);",
-        [
-            get_secret(s.r2_access_key_secret, s.gsm_project),
-            get_secret(s.r2_secret_key_secret, s.gsm_project),
-            get_secret(s.r2_account_id_secret, s.gsm_project),
-        ],
+        [r2_key, r2_secret, r2_account],
     )
-    os.environ["PGPASSWORD"] = get_secret(s.lake_pg_password_secret, s.gsm_project)
+    os.environ["PGPASSWORD"] = pg_password
     opts = " (READ_ONLY)" if read_only else ""
     con.execute(
         f"ATTACH 'ducklake:postgres:dbname={s.lake_pg_dbname} host={s.lake_pg_host} "

--- a/src/cdsci/lake/connect.py
+++ b/src/cdsci/lake/connect.py
@@ -105,7 +105,9 @@ def lake_connect(
     # persistent `pg_main` secret in the default `~/.duckdb/stored_secrets` causing
     # ATTACH failures: "Ambiguity detected for secret name 'pg_main'" (temp +
     # persistent) and "Unknown secret storage found: 'local_file'".
-    secret_dir = os.path.join(tempfile.gettempdir(), "cdsci-lake-duckdb-secrets")
+    secret_dir = os.path.join(
+        tempfile.gettempdir(), f"cdsci-lake-duckdb-secrets-{os.getuid()}"
+    )
     os.makedirs(secret_dir, exist_ok=True)
     con = duckdb.connect(config={"secret_directory": secret_dir})
     con.execute("INSTALL httpfs; LOAD httpfs;")

--- a/src/cdsci/lake/ops.py
+++ b/src/cdsci/lake/ops.py
@@ -70,6 +70,10 @@ class Source:
     distribution: str
     license: str
     watermark_strategy: str | None = None
+    # The producer that owns this source (ADR-0011 §4). The shared ledger is
+    # multi-producer, so each row records which writer registered it (`cdsci`,
+    # `omicidx`), making "show me all of <producer>'s sources/loads" one query.
+    writer: str = "cdsci"
 
 
 SOURCES: tuple[Source, ...] = (
@@ -104,17 +108,20 @@ SOURCES: tuple[Source, ...] = (
 
 
 def bootstrap(con: duckdb.DuckDBPyConnection) -> None:
-    """Create the ``lake_ops`` schema + tables (if absent) and refresh the registry.
+    """Create the ``lake_ops`` schema + tables (if absent). Schema only.
 
-    Idempotent and cheap: ``CREATE … IF NOT EXISTS`` plus a delete-then-insert of
-    :data:`SOURCES`. Assumes the ``ops`` database is already attached.
+    Idempotent and cheap: ``CREATE … IF NOT EXISTS``. Assumes the ``ops`` database
+    is already attached. Does **not** seed the source registry — each producer
+    registers its own sources via :func:`register_sources` at its load entrypoint
+    (ADR-0011 §4), so the shared ledger stays per-producer and the dependency arrow
+    stays correct (a producer's source list lives with the producer).
     """
     con.execute(f"CREATE SCHEMA IF NOT EXISTS {OPS}.{OPS_SCHEMA};")
     con.execute(
         f"""CREATE TABLE IF NOT EXISTS {_t("source")} (
             name TEXT, lake_schema TEXT, description TEXT, cadence TEXT,
             distribution TEXT, license TEXT, watermark_strategy TEXT,
-            registered_at TIMESTAMPTZ
+            writer TEXT, registered_at TIMESTAMPTZ
         );"""
     )
     con.execute(
@@ -135,20 +142,33 @@ def bootstrap(con: duckdb.DuckDBPyConnection) -> None:
             backing_table TEXT, status TEXT, published_at TIMESTAMPTZ
         );"""
     )
-    _seed_sources(con)
 
 
-def _seed_sources(con: duckdb.DuckDBPyConnection) -> None:
-    """Refresh the source registry to match :data:`SOURCES` (delete-then-insert)."""
-    for s in SOURCES:
-        con.execute(f"DELETE FROM {_t('source')} WHERE name = ?", [s.name])
+def register_sources(
+    con: duckdb.DuckDBPyConnection,
+    *,
+    writer: str,
+    sources: tuple[Source, ...],
+) -> None:
+    """Register ``sources`` under producer ``writer`` (delete-then-insert; ADR-0011 §4).
+
+    Each producer calls this once at its load entrypoint with its own source list —
+    ``bootstrap`` no longer seeds, so the registry is per-producer. Idempotent and
+    self-healing: the delete-then-insert is scoped to ``(name, writer)`` so a
+    re-register refreshes a producer's rows without touching another producer's.
+    """
+    for s in sources:
+        con.execute(
+            f"DELETE FROM {_t('source')} WHERE name = ? AND writer = ?",
+            [s.name, writer],
+        )
         con.execute(
             f"INSERT INTO {_t('source')} "
             "(name, lake_schema, description, cadence, distribution, license, "
-            " watermark_strategy, registered_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, current_timestamp)",
+            " watermark_strategy, writer, registered_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, current_timestamp)",
             [s.name, s.lake_schema, s.description, s.cadence, s.distribution,
-             s.license, s.watermark_strategy],
+             s.license, s.watermark_strategy, writer],
         )
 
 
@@ -165,9 +185,11 @@ class Run:
     target: str
     version: str | None
     snapshot_before: int | None
+    writer: str = "cdsci"  # producer id; derived from the registry in run()
     rows: int | None = None
     snapshot_after: int | None = None
     status: str | None = None
+    extra: dict | None = None  # per-producer commit_extra_info keys (ADR-0011 §5)
     _txn_depth: int = 0  # re-entrancy guard for nested attribute() blocks
 
     @property
@@ -192,8 +214,9 @@ class Run:
         """Wrap the enclosed write(s) in one **self-describing** DuckLake snapshot.
 
         Opens a transaction, stamps the snapshot it will produce with
-        ``author='cdsci:<source>'``, a ``commit_message``, and a JSON
-        ``commit_extra_info`` (``{writer, source, target, version, run_id, op}``)
+        ``author='<writer>:<source>'``, a ``commit_message``, and a JSON
+        ``commit_extra_info`` (canonical ``{writer, source, target, version,
+        run_id, op}`` plus any per-producer :attr:`extra` keys, ADR-0011 §5)
         via ``set_commit_message``, runs the block, and commits. So the catalog
         itself attributes the snapshot — no ledger join, no table-id resolution
         (ADR-0007). One snapshot per block; the block rolls back on error.
@@ -216,14 +239,17 @@ class Run:
                 self._txn_depth -= 1
             return
 
-        extra = json.dumps({
-            "writer": "cdsci", "source": self.source, "target": self.target,
+        info: dict[str, Any] = {
+            "writer": self.writer, "source": self.source, "target": self.target,
             "version": self.version, "run_id": self.run_id, "op": op,
-        })
+        }
+        if self.extra:  # per-producer keys (e.g. omicidx's prefect_run_id)
+            info.update(self.extra)
+        extra = json.dumps(info)
         self.con.execute("BEGIN;")
         self.con.execute(
             f"CALL {LAKE}.set_commit_message(?, ?, extra_info => ?);",
-            [f"cdsci:{self.source}", message or f"{self.source}: {op}", extra],
+            [f"{self.writer}:{self.source}", message or f"{self.source}: {op}", extra],
         )
         self._txn_depth = 1
         try:
@@ -242,6 +268,49 @@ def _max_snapshot(con: duckdb.DuckDBPyConnection) -> int | None:
     return con.execute(f"SELECT max(snapshot_id) FROM {LAKE}.snapshots()").fetchone()[0]
 
 
+_SOURCES_BY_NAME: dict[str, Source] = {s.name: s for s in SOURCES}
+
+
+def _self_register(con: duckdb.DuckDBPyConnection, source: str) -> None:
+    """Lazily register a **built-in** ``source`` on first run, if not already present.
+
+    Gives all cdsci ingestors correct attribution with no per-ingestor edits and
+    without the substrate force-seeding on connect: a source name in the built-in
+    :data:`SOURCES` self-registers (under its own ``writer``) the first time it
+    runs. A foreign producer's source (not in ``SOURCES``) is left untouched — it
+    registers itself explicitly via :func:`register_sources`. The write lands in the
+    ``ops`` attachment (never a lake snapshot), like the run-row INSERT beside it.
+    """
+    src = _SOURCES_BY_NAME.get(source)
+    if src is None:
+        return
+    exists = con.execute(
+        f"SELECT 1 FROM {_t('source')} WHERE name = ? LIMIT 1", [source]
+    ).fetchone()
+    if exists is None:
+        register_sources(con, writer=src.writer, sources=(src,))
+
+
+def _writer_for(con: duckdb.DuckDBPyConnection, source: str) -> str:
+    """The producer that registered ``source`` (ADR-0011 §5); the source name if unregistered.
+
+    ``run`` derives ``writer`` from the registry rather than taking it as a param, so
+    call sites stay stable. A source not yet registered (``bootstrap`` no longer
+    seeds) falls back to its own name with a warning — attribution degrades to
+    ``<source>:<source>`` but never crashes a load.
+    """
+    row = con.execute(
+        f"SELECT writer FROM {_t('source')} WHERE name = ? LIMIT 1", [source]
+    ).fetchone()
+    if row and row[0]:
+        return row[0]
+    logger.warning(
+        "source {!r} not registered in lake_ops.source; defaulting writer to the "
+        "source name (call ops.register_sources at your load entrypoint)", source,
+    )
+    return source
+
+
 @contextmanager
 def run(
     con: duckdb.DuckDBPyConnection,
@@ -250,6 +319,7 @@ def run(
     target: str,
     version: str | None = None,
     host: str | None = None,
+    extra: dict | None = None,
 ) -> Iterator[Run]:
     """Record one ``lake_ops.run`` row around a curate/upsert.
 
@@ -258,12 +328,18 @@ def run(
     ``snapshot_after`` and finalize status — ``error`` if the block raised, else
     ``idempotent`` when no snapshot was added, else ``success``.
 
+    ``writer`` is **derived** from the source registry (not a param, so existing
+    call sites don't change); ``extra`` is an optional per-producer dict merged into
+    the snapshot ``commit_extra_info`` on top of the canonical keys (ADR-0011 §5).
+
         with ops.run(con, source="icite", target=target, version=version) as r:
             r.rows = curate(con, paths, version, target=target, limit=limit)
         return r.summary()
     """
     rid = str(uuid.uuid4())
     host = host or socket.gethostname()
+    _self_register(con, source)  # built-in sources self-register on first run
+    writer = _writer_for(con, source)
     before = _max_snapshot(con)
     con.execute(
         f"INSERT INTO {_t('run')} "
@@ -276,7 +352,7 @@ def run(
         "start → {} (version={}, snapshot_before={}, run_id={})",
         target, version, before, rid,
     )
-    r = Run(con, rid, source, target, version, before)
+    r = Run(con, rid, source, target, version, before, writer=writer, extra=extra)
     token = _ACTIVE_RUN.set(r)
     try:
         try:

--- a/src/cdsci/lake/ops.py
+++ b/src/cdsci/lake/ops.py
@@ -124,6 +124,11 @@ def bootstrap(con: duckdb.DuckDBPyConnection) -> None:
             writer TEXT, registered_at TIMESTAMPTZ
         );"""
     )
+    # Migrate a pre-PR `source` table (created before the writer column, so the
+    # CREATE IF NOT EXISTS above is a no-op on it) — else register_sources INSERTs
+    # into a missing column and crashes on the first real run (ADR-0011 §4).
+    con.execute(f"ALTER TABLE {_t('source')} ADD COLUMN IF NOT EXISTS writer TEXT;")
+    con.execute(f"UPDATE {_t('source')} SET writer = 'cdsci' WHERE writer IS NULL;")
     con.execute(
         f"""CREATE TABLE IF NOT EXISTS {_t("run")} (
             run_id TEXT, source TEXT, target TEXT, version TEXT, status TEXT,
@@ -239,13 +244,13 @@ class Run:
                 self._txn_depth -= 1
             return
 
-        info: dict[str, Any] = {
+        canonical = {
             "writer": self.writer, "source": self.source, "target": self.target,
             "version": self.version, "run_id": self.run_id, "op": op,
         }
-        if self.extra:  # per-producer keys (e.g. omicidx's prefect_run_id)
-            info.update(self.extra)
-        extra = json.dumps(info)
+        # Per-producer keys (e.g. omicidx's prefect_run_id) merge in, but the
+        # canonical keys are authoritative — a colliding extra key can't override.
+        extra = json.dumps({**(self.extra or {}), **canonical})
         self.con.execute("BEGIN;")
         self.con.execute(
             f"CALL {LAKE}.set_commit_message(?, ?, extra_info => ?);",
@@ -285,7 +290,8 @@ def _self_register(con: duckdb.DuckDBPyConnection, source: str) -> None:
     if src is None:
         return
     exists = con.execute(
-        f"SELECT 1 FROM {_t('source')} WHERE name = ? LIMIT 1", [source]
+        f"SELECT 1 FROM {_t('source')} WHERE name = ? AND writer = ? LIMIT 1",
+        [source, src.writer],
     ).fetchone()
     if exists is None:
         register_sources(con, writer=src.writer, sources=(src,))
@@ -299,11 +305,19 @@ def _writer_for(con: duckdb.DuckDBPyConnection, source: str) -> str:
     seeds) falls back to its own name with a warning — attribution degrades to
     ``<source>:<source>`` but never crashes a load.
     """
-    row = con.execute(
-        f"SELECT writer FROM {_t('source')} WHERE name = ? LIMIT 1", [source]
-    ).fetchone()
-    if row and row[0]:
-        return row[0]
+    writers = [
+        w for (w,) in con.execute(
+            f"SELECT DISTINCT writer FROM {_t('source')} WHERE name = ?", [source]
+        ).fetchall() if w
+    ]
+    if len(writers) == 1:
+        return writers[0]
+    if len(writers) > 1:
+        raise ValueError(
+            f"source {source!r} is registered under multiple writers "
+            f"{sorted(writers)}; attribution is ambiguous — a producer sharing a "
+            "source name must register/disambiguate explicitly"
+        )
     logger.warning(
         "source {!r} not registered in lake_ops.source; defaulting writer to the "
         "source name (call ops.register_sources at your load entrypoint)", source,

--- a/tests/test_europepmc.py
+++ b/tests/test_europepmc.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import pytest
 
-from cdsci.lake import Settings, lake_connect, table_exists
+from cdsci.lake import Settings, lake_connect, ops, table_exists
 from cdsci.lake.sources import europepmc
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -25,6 +25,9 @@ def lake_settings(tmp_path: Path) -> Settings:
 def test_europepmc_curate_one_tidy_table(lake_settings: Settings):
     con = lake_connect(lake_settings)
     try:
+        # curate() is called directly (not via ops.run), so register explicitly —
+        # the substrate no longer seeds on connect (ADR-0011 §4).
+        ops.register_sources(con, writer="cdsci", sources=ops.SOURCES)
         # 4 fixture rows, but the duplicate (MINT-1, PMC1) collapses → 3 distinct keys.
         n = europepmc.curate(con, "mint", FIXTURES / "europepmc_mint.csv", "test-2026-06")
         assert n == 3
@@ -48,7 +51,7 @@ def test_europepmc_curate_one_tidy_table(lake_settings: Settings):
             "SELECT count(*) FROM lake.europepmc.annotations"
         ).fetchone()[0] == 5  # 3 mint + 2 chebi
 
-        # The ops ledger registered europepmc on the write-mode connect.
+        # The ops ledger has europepmc registered (explicitly, above).
         n_src = con.execute(
             "SELECT count(*) FROM ops.lake_ops.source WHERE name = 'europepmc'"
         ).fetchone()[0]

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -42,6 +42,30 @@ def test_connect_creates_tables_but_does_not_seed(lake_settings: Settings):
         con.close()
 
 
+def test_bootstrap_migrates_pre_writer_source_table(lake_settings: Settings):
+    """bootstrap adds+backfills `writer` on a pre-PR `source` table (ADR-0011 §1 review)."""
+    con = lake_connect(lake_settings)
+    try:
+        # Simulate the old schema: drop writer, seed a legacy row without it.
+        con.execute("ALTER TABLE ops.lake_ops.source DROP COLUMN writer")
+        con.execute(
+            "INSERT INTO ops.lake_ops.source (name, lake_schema, registered_at) "
+            "VALUES ('icite', 'icite', current_timestamp)"
+        )
+        ops.bootstrap(con)  # must ADD COLUMN IF NOT EXISTS + backfill
+
+        assert con.execute(
+            "SELECT writer FROM ops.lake_ops.source WHERE name = 'icite'"
+        ).fetchone()[0] == "cdsci"
+        # register_sources now works against the migrated table.
+        ops.register_sources(con, writer="cdsci", sources=ops.SOURCES)
+        assert con.execute(
+            "SELECT count(*) FROM ops.lake_ops.source"
+        ).fetchone()[0] == len(ops.SOURCES)
+    finally:
+        con.close()
+
+
 def test_register_sources_populates_writer_and_is_idempotent(lake_settings: Settings):
     """Explicit register_sources seeds the writer column; a re-register refreshes, not dupes."""
     con = lake_connect(lake_settings)
@@ -181,6 +205,46 @@ def test_run_foreign_producer_source(lake_settings: Settings):
         # "sra" isn't in SOURCES → no self-registration, so no cdsci rows leaked in.
         names = {n for (n,) in con.execute("SELECT name FROM ops.lake_ops.source").fetchall()}
         assert names == {"sra"}
+    finally:
+        con.close()
+
+
+def test_extra_cannot_override_canonical_keys(lake_settings: Settings):
+    """A colliding `extra` key can't clobber a canonical key; other extras still flow."""
+    con = lake_connect(lake_settings)
+    try:
+        src = "SELECT * FROM (VALUES (1,'a')) v(id,val)"
+        with ops.run(
+            con, source="icite", target="lake.main.t4", version="v1",
+            extra={"writer": "nope", "prefect_run_id": "x"},
+        ) as r:
+            r.rows = upsert(con, "lake.main.t4", src, key="id")
+        (extra,) = con.execute(
+            "SELECT commit_extra_info FROM lake.snapshots() WHERE snapshot_id = ?",
+            [r.snapshot_after],
+        ).fetchone()
+        meta = json.loads(extra)
+        assert meta["writer"] == "cdsci"  # canonical wins over extra's "nope"
+        assert meta["prefect_run_id"] == "x"  # non-colliding extra still flows
+    finally:
+        con.close()
+
+
+def test_writer_for_raises_on_ambiguous_registration(lake_settings: Settings):
+    """One name under two writers → run() fails loud rather than picking nondeterministically."""
+    con = lake_connect(lake_settings)
+    try:
+        ops.register_sources(
+            con, writer="cdsci",
+            sources=(ops.Source("shared", "a", "d", "daily", "x", "y"),),
+        )
+        ops.register_sources(
+            con, writer="omicidx",
+            sources=(ops.Source("shared", "b", "d", "daily", "x", "y"),),
+        )
+        with pytest.raises(ValueError, match="multiple writers"):
+            with ops.run(con, source="shared", target="lake.x.y"):
+                pass
     finally:
         con.close()
 

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -20,13 +20,11 @@ def lake_settings(tmp_path: Path) -> Settings:
     return Settings(storage_base_uri=f"file://{tmp_path}")
 
 
-def test_bootstrap_seeds_registry(lake_settings: Settings):
-    """A write-mode connect attaches ops, creates tables, and seeds the registry."""
+def test_connect_creates_tables_but_does_not_seed(lake_settings: Settings):
+    """bootstrap is schema-only; the substrate never force-seeds on connect (ADR-0011 §4)."""
     con = lake_connect(lake_settings)
     try:
-        names = {r[0] for r in con.execute("SELECT name FROM ops.lake_ops.source").fetchall()}
-        assert names == {s.name for s in ops.SOURCES}
-        # All four ledger tables exist.
+        # All four ledger tables exist...
         tables = {
             r[0]
             for r in con.execute(
@@ -35,17 +33,28 @@ def test_bootstrap_seeds_registry(lake_settings: Settings):
             ).fetchall()
         }
         assert {"source", "run", "watermark", "dataset_contract"} <= tables
+        # ...but the registry is empty — no producer's sources are force-registered.
+        assert con.execute("SELECT count(*) FROM ops.lake_ops.source").fetchone()[0] == 0
+
+        ops.bootstrap(con)  # a second bootstrap is still schema-only — must not seed
+        assert con.execute("SELECT count(*) FROM ops.lake_ops.source").fetchone()[0] == 0
     finally:
         con.close()
 
 
-def test_bootstrap_idempotent_no_duplicate_sources(lake_settings: Settings):
-    """Re-connecting refreshes (not duplicates) the registry rows."""
-    lake_connect(lake_settings).close()
+def test_register_sources_populates_writer_and_is_idempotent(lake_settings: Settings):
+    """Explicit register_sources seeds the writer column; a re-register refreshes, not dupes."""
     con = lake_connect(lake_settings)
     try:
-        n = con.execute("SELECT count(*) FROM ops.lake_ops.source").fetchone()[0]
-        assert n == len(ops.SOURCES)
+        ops.register_sources(con, writer="cdsci", sources=ops.SOURCES)
+        rows = con.execute("SELECT name, writer FROM ops.lake_ops.source").fetchall()
+        assert {name for name, _ in rows} == {s.name for s in ops.SOURCES}
+        assert {writer for _, writer in rows} == {"cdsci"}
+
+        ops.register_sources(con, writer="cdsci", sources=ops.SOURCES)
+        assert con.execute(
+            "SELECT count(*) FROM ops.lake_ops.source"
+        ).fetchone()[0] == len(ops.SOURCES)
     finally:
         con.close()
 
@@ -67,9 +76,17 @@ def test_run_records_success_then_idempotent(lake_settings: Settings):
     """A real upsert → status 'success'; an identical re-run → 'idempotent'."""
     con = lake_connect(lake_settings)
     try:
+        # icite is NOT pre-registered (connect no longer seeds) — the run must
+        # self-register the built-in source so attribution is cdsci:icite.
+        assert con.execute(
+            "SELECT count(*) FROM ops.lake_ops.source WHERE name='icite'"
+        ).fetchone()[0] == 0
         src = "SELECT * FROM (VALUES (1,'a'),(2,'b')) v(id,val)"
         with ops.run(con, source="icite", target="lake.main.t", version="2026-05") as r:
             r.rows = upsert(con, "lake.main.t", src, key="id")
+        assert con.execute(
+            "SELECT writer FROM ops.lake_ops.source WHERE name='icite'"
+        ).fetchone()[0] == "cdsci"
         assert r.status == "success"
         assert r.changed is True
         assert r.summary() == {
@@ -116,6 +133,64 @@ def test_run_records_error_and_reraises(lake_settings: Settings):
         assert row["status"] == "error"
         assert "boom" in row["error"]
         assert row["finished_at"] is not None
+    finally:
+        con.close()
+
+
+def test_run_derives_writer_and_merges_extra(lake_settings: Settings):
+    """run() derives writer from the registry and merges extra= into commit_extra_info."""
+    con = lake_connect(lake_settings)
+    try:
+        src = "SELECT * FROM (VALUES (1,'a')) v(id,val)"
+        with ops.run(
+            con, source="icite", target="lake.main.t2", version="v1",
+            extra={"prefect_run_id": "abc-123"},
+        ) as r:
+            assert r.writer == "cdsci"  # self-registered built-in, then derived
+            r.rows = upsert(con, "lake.main.t2", src, key="id")
+
+        author, extra = con.execute(
+            "SELECT author, commit_extra_info FROM lake.snapshots() WHERE snapshot_id = ?",
+            [r.snapshot_after],
+        ).fetchone()
+        assert author == "cdsci:icite"
+        meta = json.loads(extra)
+        assert meta["writer"] == "cdsci"
+        # Per-producer key flows through on top of the canonical keys.
+        assert meta["prefect_run_id"] == "abc-123"
+    finally:
+        con.close()
+
+
+def test_run_foreign_producer_source(lake_settings: Settings):
+    """A foreign producer registers its own source; run() attributes it, touches no cdsci rows."""
+    con = lake_connect(lake_settings)
+    try:
+        ops.register_sources(
+            con, writer="omicidx",
+            sources=(ops.Source("sra", "omicidx", "SRA", "daily", "ncbi", "us-public-domain"),),
+        )
+        src = "SELECT * FROM (VALUES (1,'a')) v(id,val)"
+        with ops.run(con, source="sra", target="lake.omicidx.sra", version="v1") as r:
+            assert r.writer == "omicidx"
+            r.rows = upsert(con, "lake.omicidx.sra", src, key="id")
+        author = con.execute(
+            "SELECT author FROM lake.snapshots() WHERE snapshot_id = ?", [r.snapshot_after]
+        ).fetchone()[0]
+        assert author == "omicidx:sra"
+        # "sra" isn't in SOURCES → no self-registration, so no cdsci rows leaked in.
+        names = {n for (n,) in con.execute("SELECT name FROM ops.lake_ops.source").fetchall()}
+        assert names == {"sra"}
+    finally:
+        con.close()
+
+
+def test_run_unregistered_source_falls_back_to_source_name(lake_settings: Settings):
+    """A source neither in SOURCES nor registered → warns, writer defaults to its name."""
+    con = lake_connect(lake_settings)
+    try:
+        with ops.run(con, source="not_a_real_source", target="lake.x.y") as r:
+            assert r.writer == "not_a_real_source"
     finally:
         con.close()
 

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -242,9 +242,10 @@ def test_writer_for_raises_on_ambiguous_registration(lake_settings: Settings):
             con, writer="omicidx",
             sources=(ops.Source("shared", "b", "d", "daily", "x", "y"),),
         )
-        with pytest.raises(ValueError, match="multiple writers"):
-            with ops.run(con, source="shared", target="lake.x.y"):
-                pass
+        with pytest.raises(ValueError, match="multiple writers"), ops.run(
+            con, source="shared", target="lake.x.y"
+        ):
+            pass
     finally:
         con.close()
 

--- a/tests/test_reliance.py
+++ b/tests/test_reliance.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import pytest
 
-from cdsci.lake import Settings, lake_connect, table_exists
+from cdsci.lake import Settings, lake_connect, ops, table_exists
 from cdsci.lake.sources import reliance
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -26,6 +26,9 @@ def lake_settings(tmp_path: Path) -> Settings:
 def test_reliance_citations_and_pairs(lake_settings: Settings):
     con = lake_connect(lake_settings)
     try:
+        # curate() is called directly here (not via ops.run), so register the
+        # source explicitly — the substrate no longer seeds on connect (ADR-0011 §4).
+        ops.register_sources(con, writer="cdsci", sources=ops.SOURCES)
         # citations: 5 fixture rows → 3 distinct keys (one dup collapses, blank drops).
         n = reliance.curate(con, "citations", FIXTURES / "reliance_pcs_oa.csv", "test")
         assert n == 3


### PR DESCRIPTION
## What

The write-side half of the "peer publishers" premise (ADR-0001): omicidx (and future producers) can now write the shared catalog through this library instead of a hand-rolled path. This PR lands the **cdsci-lake side** of the contract; the omicidx migration follows in its own PR, pinning this one.

## Contract (ADRs in this PR)

- **ADR-0011** — the multi-producer write contract (7 decisions)
- **ADR-0012** — defer the gateway/config-file target model (triggers: a frozen-snapshot target, or sqlmesh adoption)
- **ADR-0013** — the lake write path is **EL/`upsert`-only**; derived tables + `rebuild` defer to the transform layer

## Changes

**`ops.py`**
- `Source.writer` + a `writer` column on `lake_ops.source`; `run()` **derives** `writer` from the registry (signature unchanged) and merges an optional per-producer `extra` dict into the snapshot `commit_extra_info`; snapshot `author = "<writer>:<source>"`.
- `bootstrap()` seeds nothing. `register_sources(con, *, writer, sources)` is the explicit API. Built-in `SOURCES` **self-register lazily inside `run()`**, so the substrate never force-registers a producer's rows on connect — a foreign producer's source (e.g. omicidx's `sra`) touches no cdsci rows.

**`connect.py` / `config.py`**
- Pluggable credential source (`gsm` | `env`) so omicidx's Prefect workers connect without `gcloud`. **The GSM path is behaviorally unchanged.**
- Isolate DuckDB's `secret_directory` to sidestep stale-secret ATTACH failures (ambiguous `pg_main` / unknown `local_file` storage), ported from omicidx.

## Review focus

- `_attach_ops` / `lake_connect` must **not** register any producer's sources on connect (the reason `run()` self-registers instead).
- The `cred_source="gsm"` branch should read as byte-for-byte the prior behavior.
- `test_run_foreign_producer_source` asserts the isolation (`lake_ops.source` holds only the foreign source, no cdsci `SOURCES` leak).

## Tests

`uv run pytest tests/` → **37 passed, 3 skipped** (pre-existing integration: Census download, `RUN_INTEGRATION`, live GSM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
