### PR TITLE
feat: transform + reverse-ETL layer (ADR-0015)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Sync dependencies (read client + ingest extra + dev tools)
-        run: uv sync --extra ingest
+      - name: Sync dependencies (all extras + dev tools)
+        run: uv sync --all-extras
 
       - name: Lint (ruff)
         run: uv run ruff check src/ tests/

--- a/models/ref/id_crosswalk.sql
+++ b/models/ref/id_crosswalk.sql
@@ -1,0 +1,68 @@
+-- ref.id_crosswalk (ROADMAP.md, ADR-0015 pilot model): PMID <-> DOI <-> PMCID <->
+-- core_project_num <-> NCT. One row per PMID -- the common key across all five
+-- source tables. DOI/PMCID are single-valued (any_value across sources, since a
+-- pmid rarely disagrees on its own DOI/PMCID); grants and trials are genuinely
+-- many-to-one on a pmid (one paper can cite many grants/trials), kept as arrays
+-- rather than exploded, so a consumer chooses whether to UNNEST.
+--
+-- ponytail: any_value() picks one source's DOI/PMCID per pmid with no conflict
+-- resolution or provenance -- if sources disagree, whichever DuckDB scans first
+-- wins silently. Upgrade to a per-source doi_map (favor icite > openalex > pmc)
+-- if a consumer needs to know which source asserted an id, or a conflict shows
+-- up in practice.
+WITH pmids AS (
+    SELECT pmid FROM lake.icite.metadata WHERE pmid IS NOT NULL
+    UNION
+    SELECT pmid FROM lake.pmc.documents WHERE pmid IS NOT NULL
+    UNION
+    SELECT pmid FROM lake.openalex.works WHERE pmid IS NOT NULL
+    UNION
+    SELECT pmid FROM lake.reporter.publink WHERE pmid IS NOT NULL
+    UNION
+    SELECT pmid FROM lake.ctgov.references WHERE pmid IS NOT NULL
+),
+doi_by_pmid AS (
+    SELECT pmid, any_value(doi) AS doi
+    FROM (
+        SELECT pmid, lower(doi) AS doi FROM lake.icite.metadata WHERE doi IS NOT NULL
+        UNION ALL
+        SELECT pmid, lower(doi) AS doi FROM lake.openalex.works
+        WHERE doi IS NOT NULL AND pmid IS NOT NULL
+        UNION ALL
+        SELECT pmid, lower(doi) AS doi FROM lake.pmc.documents WHERE doi IS NOT NULL
+    )
+    GROUP BY pmid
+),
+pmcid_by_pmid AS (
+    SELECT pmid, any_value(pmcid) AS pmcid
+    FROM (
+        SELECT pmid, pmcid FROM lake.pmc.documents WHERE pmid IS NOT NULL
+        UNION ALL
+        SELECT pmid, pmcid FROM lake.openalex.works
+        WHERE pmid IS NOT NULL AND pmcid IS NOT NULL
+    )
+    GROUP BY pmid
+),
+grants_by_pmid AS (
+    SELECT pmid, list(DISTINCT project_number) AS core_project_nums
+    FROM lake.reporter.publink
+    WHERE pmid IS NOT NULL
+    GROUP BY pmid
+),
+ncts_by_pmid AS (
+    SELECT pmid, list(DISTINCT nct_id) AS nct_ids
+    FROM lake.ctgov.references
+    WHERE pmid IS NOT NULL
+    GROUP BY pmid
+)
+SELECT
+    p.pmid,
+    d.doi,
+    c.pmcid,
+    g.core_project_nums,
+    n.nct_ids
+FROM pmids p
+LEFT JOIN doi_by_pmid d USING (pmid)
+LEFT JOIN pmcid_by_pmid c USING (pmid)
+LEFT JOIN grants_by_pmid g USING (pmid)
+LEFT JOIN ncts_by_pmid n USING (pmid)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,13 @@ dashboard = [
     "fastapi>=0.115.0",
     "uvicorn>=0.30.0",
 ]
+# The transform + reverse-ETL layer (ADR-0015). sqlglot does dependency-graph +
+# lineage parsing only — DuckDB (base) stays the sole execution engine; typer is
+# the CLI, same floor as [ingest].
+transform = [
+    "sqlglot>=27",
+    "typer>=0.26.7",
+]
 
 [build-system]
 requires = ["uv_build>=0.8.11,<0.9.0"]

--- a/scripts/smoketest_icegate.py
+++ b/scripts/smoketest_icegate.py
@@ -1,0 +1,88 @@
+"""One-off smoke test for targets.py's iceberg adapter against the real,
+live bioc-on-ice icegate instance. NOT a pytest test (needs a real secret +
+network) -- run manually:
+
+    uv run python scripts/smoketest_icegate.py
+
+Writes a scratch table to the `annotation` namespace (write-scoped there per
+bioc-on-ice's icegate.yaml), reads it back, then drops it. Prints PASS/FAIL
+only -- the token never gets printed or written to disk.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+from cdsci.lake.connect import lake_connect
+from cdsci.lake.transform.targets import Target, publish
+
+CATALOG = "bioconice"
+ENDPOINT = "https://icegate-bioconice.seandavi.workers.dev"
+NAMESPACE = "annotation"
+TABLE = "_cdsci_lake_smoketest"
+
+
+def main() -> int:
+    token = subprocess.run(
+        ["gcloud", "secrets", "versions", "access", "latest",
+         "--secret=bioconice-icegate-key-seandavi", "--project=cdsci-infra"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+    con = lake_connect()
+    try:
+        con.execute(
+            "CREATE SCHEMA IF NOT EXISTS lake.smoketest; "
+            "CREATE OR REPLACE TABLE lake.smoketest.genes AS "
+            "SELECT * FROM (VALUES "
+            "  ('CDSCI0001', 'faux-gene-a', 'chr_test'), "
+            "  ('CDSCI0002', 'faux-gene-b', 'chr_test') "
+            ") v(gene_id, symbol, chrom)"
+        )
+        target = Target(
+            "iceberg",
+            {
+                "token": token,
+                "catalog": CATALOG,
+                "endpoint": ENDPOINT,
+                "namespace": NAMESPACE,
+                "table": TABLE,
+            },
+        )
+        publish(con, "lake.smoketest.genes", target, date="2026-08-07")
+        # publish() detaches its own catalog handle on exit (adapter contract:
+        # no lingering attachment) -- re-attach here to verify + clean up.
+        con.execute("INSTALL iceberg; LOAD iceberg;")
+        con.execute(
+            "CREATE OR REPLACE SECRET _verify_ice (TYPE ICEBERG, TOKEN ?);", [token]
+        )
+        con.execute(
+            f"ATTACH '{CATALOG}' AS _verify_cat "
+            f"(TYPE ICEBERG, ENDPOINT '{ENDPOINT}', SECRET _verify_ice);"
+        )
+        try:
+            rows = con.execute(
+                f"SELECT * FROM _verify_cat.{NAMESPACE}.{TABLE} ORDER BY gene_id"
+            ).fetchall()
+            expected = [
+                ("CDSCI0001", "faux-gene-a", "chr_test"),
+                ("CDSCI0002", "faux-gene-b", "chr_test"),
+            ]
+            if rows != expected:
+                print(f"FAIL: read back {rows!r}, expected {expected!r}")
+                return 1
+            print(f"PASS: wrote + read back {len(rows)} rows via icegate ({CATALOG}.{NAMESPACE}.{TABLE})")
+
+            # Clean up -- this is a smoke test table, not real bioc-on-ice data.
+            con.execute(f"DROP TABLE _verify_cat.{NAMESPACE}.{TABLE};")
+            print("cleaned up: dropped the scratch table")
+            return 0
+        finally:
+            con.execute("DETACH _verify_cat;")
+    finally:
+        con.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/cdsci/lake/transform/__init__.py
+++ b/src/cdsci/lake/transform/__init__.py
@@ -1,0 +1,12 @@
+"""``cdsci.lake.transform`` — the SQL-file transform + reverse-ETL layer (ADR-0015).
+
+Un-defers the transform layer ADR-0012/0013 parked: a model is a plain SQL file
+(one ``CREATE OR REPLACE TABLE ... AS SELECT`` per file), DuckDB is the sole
+execution engine, and ``sqlglot`` does two jobs only — dependency-graph
+extraction (:mod:`.graph`) and best-effort column lineage (:mod:`.lineage`) —
+never orchestration. This is where ADR-0013's parked ``rebuild`` verb lives,
+scoped to this module; the EL write path (:func:`cdsci.lake.connect.upsert`)
+stays ``upsert``-only.
+"""
+
+from __future__ import annotations

--- a/src/cdsci/lake/transform/__main__.py
+++ b/src/cdsci/lake/transform/__main__.py
@@ -1,0 +1,86 @@
+"""CLI: ``python -m cdsci.lake.transform`` — run SQL-file transform models (ADR-0015).
+
+Mirrors ``maintenance_cli.py``'s shape: a typer app, ``--log-level`` via loguru,
+``lake_connect()`` per command. ``--models-dir`` (default ``models``, the repo's
+top-level SQL-file directory) is the one piece of shared state, threaded through
+``typer.Context``.
+"""
+
+from __future__ import annotations
+
+import typer
+
+from ..connect import lake_connect
+from ..log import configure
+from . import runner
+from .graph import build_graph, topological_order
+from .models import load_models
+
+app = typer.Typer(
+    help="SQL-file transform + reverse-ETL models: run, inspect the dependency graph.",
+    add_completion=False,
+)
+
+
+@app.callback()
+def _main(
+    ctx: typer.Context,
+    log_level: str = typer.Option("INFO", "--log-level", help="loguru level."),
+    models_dir: str = typer.Option("models", "--models-dir", help="Directory of *.sql models."),
+) -> None:
+    configure(log_level)
+    ctx.obj = models_dir
+
+
+@app.command("list")
+def list_cmd(ctx: typer.Context) -> None:
+    """List discovered models and their source files."""
+    models = load_models(ctx.obj)
+    for target in sorted(models):
+        typer.echo(f"  {target}  ({models[target].path})")
+    typer.echo(f"  ({len(models)} model(s))")
+
+
+@app.command("graph")
+def graph_cmd(ctx: typer.Context) -> None:
+    """Print each model's dependencies and the topological execution order."""
+    models = load_models(ctx.obj)
+    g = build_graph(models)
+    for target in sorted(g):
+        deps = ", ".join(sorted(g[target])) or "(none)"
+        typer.echo(f"  {target} <- {deps}")
+    typer.echo(f"  order: {' -> '.join(topological_order(g))}")
+
+
+@app.command("run")
+def run_cmd(
+    ctx: typer.Context,
+    target: str = typer.Argument(..., help="Model target, e.g. ref.id_crosswalk."),
+) -> None:
+    """Run one model — no dependency check; use ``run-all`` for the full graph."""
+    models = load_models(ctx.obj)
+    if target not in models:
+        raise typer.BadParameter(f"no such model: {target!r} (known: {sorted(models)})")
+    con = lake_connect()
+    try:
+        rows = runner.run_model(con, models[target])
+    finally:
+        con.close()
+    typer.echo(f"  {target}: {rows} rows")
+
+
+@app.command("run-all")
+def run_all_cmd(ctx: typer.Context) -> None:
+    """Run every model in dependency order."""
+    models = load_models(ctx.obj)
+    con = lake_connect()
+    try:
+        results = runner.run_all(con, models)
+    finally:
+        con.close()
+    for target, rows in results.items():
+        typer.echo(f"  {target}: {rows} rows")
+
+
+if __name__ == "__main__":
+    app()

--- a/src/cdsci/lake/transform/graph.py
+++ b/src/cdsci/lake/transform/graph.py
@@ -17,7 +17,7 @@ from sqlglot import exp
 from .models import Model
 
 
-def model_dependencies(model: Model, known_targets: set[str]) -> set[str]:
+def _model_dependencies(model: Model, known_targets: set[str]) -> set[str]:
     """The subset of ``model``'s table references that are other known models.
 
     A reference's trailing two dotted parts (``schema.table``, ignoring any
@@ -38,7 +38,7 @@ def model_dependencies(model: Model, known_targets: set[str]) -> set[str]:
 def build_graph(models: dict[str, Model]) -> dict[str, set[str]]:
     """``{target: {targets it depends on}}`` for every model in ``models``."""
     known = set(models)
-    return {target: model_dependencies(m, known) for target, m in models.items()}
+    return {target: _model_dependencies(m, known) for target, m in models.items()}
 
 
 def topological_order(graph: dict[str, set[str]]) -> list[str]:

--- a/src/cdsci/lake/transform/graph.py
+++ b/src/cdsci/lake/transform/graph.py
@@ -1,0 +1,72 @@
+"""``cdsci.lake.transform.graph`` — dependency DAG + topological execution order.
+
+``sqlglot``'s job here is table-reference extraction only, never orchestration:
+parse each model's SQL, collect the tables it reads, and keep only the refs
+that resolve to *another model in this run*. An unresolved ref (a raw table
+this transform layer doesn't own, or a table-valued function like
+``read_parquet(...)``) is an external leaf, not an edge — the
+``geo_series_with_rnaseq_counts`` case found scoping ADR-0015 is exactly this:
+a model reading an external Parquet file has no model dependency to record.
+"""
+
+from __future__ import annotations
+
+import sqlglot
+from sqlglot import exp
+
+from .models import Model
+
+
+def model_dependencies(model: Model, known_targets: set[str]) -> set[str]:
+    """The subset of ``model``'s table references that are other known models.
+
+    A reference's trailing two dotted parts (``schema.table``, ignoring any
+    catalog prefix like ``lake.``) must match a target in ``known_targets`` to
+    count — anything else is an input, not a DAG edge.
+    """
+    deps: set[str] = set()
+    for table in sqlglot.parse_one(model.sql, read="duckdb").find_all(exp.Table):
+        parts = [p for p in (table.catalog, table.db, table.name) if p]
+        if len(parts) < 2:
+            continue  # a bare name or a table-valued function call — nothing to match
+        candidate = ".".join(parts[-2:])
+        if candidate in known_targets and candidate != model.target:
+            deps.add(candidate)
+    return deps
+
+
+def build_graph(models: dict[str, Model]) -> dict[str, set[str]]:
+    """``{target: {targets it depends on}}`` for every model in ``models``."""
+    known = set(models)
+    return {target: model_dependencies(m, known) for target, m in models.items()}
+
+
+def topological_order(graph: dict[str, set[str]]) -> list[str]:
+    """Kahn's algorithm: an execution order where every dependency runs first.
+
+    Deterministic (ties broken alphabetically) so runs and tests are
+    reproducible. Raises ``ValueError`` on a cycle — a transform DAG must be
+    acyclic by construction; there's no valid order to fall back to.
+    """
+    in_degree = dict.fromkeys(graph, 0)
+    children: dict[str, list[str]] = {n: [] for n in graph}
+    for target, deps in graph.items():
+        for dep in deps:
+            children[dep].append(target)
+            in_degree[target] += 1
+
+    ready = sorted(n for n, d in in_degree.items() if d == 0)
+    order: list[str] = []
+    while ready:
+        node = ready.pop(0)
+        order.append(node)
+        for child in children[node]:
+            in_degree[child] -= 1
+            if in_degree[child] == 0:
+                ready.append(child)
+        ready.sort()
+
+    if len(order) != len(graph):
+        remaining = sorted(set(graph) - set(order))
+        raise ValueError(f"cycle detected among transform models: {remaining}")
+    return order

--- a/src/cdsci/lake/transform/lineage.py
+++ b/src/cdsci/lake/transform/lineage.py
@@ -1,0 +1,66 @@
+"""``cdsci.lake.transform.lineage`` — column-level lineage via ``sqlglot`` (ADR-0015 §2).
+
+Best-effort, not a correctness guarantee (ADR-0015 consequences): these models
+carry no catalog schema for ``sqlglot`` to expand a ``SELECT *`` against, and
+its lineage resolution is less battle-tested than SQLMesh's on gnarly CTEs/
+window functions. An output column ``sqlglot`` can't resolve logs a warning
+and contributes no edges rather than failing the run — lineage is
+observability, not a write-path gate.
+
+Feeds ``lake_ops.lineage`` once ADR-0014's asset/lineage tables exist; until
+then this module only *computes* edges, it never writes anywhere.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import sqlglot
+from sqlglot import exp
+from sqlglot.lineage import lineage as _sqlglot_lineage
+
+from ..log import logger
+from .models import Model
+
+
+@dataclass(frozen=True)
+class LineageEdge:
+    """One output column's dependency on an upstream ``table.column``."""
+
+    target: str  # "ref.id_crosswalk"
+    target_column: str  # "pmid"
+    source_table: str  # "reporter.publink"
+    source_column: str  # "pmid"
+
+
+def model_lineage(model: Model) -> list[LineageEdge]:
+    """Best-effort column lineage for every resolvable output column of ``model``."""
+    try:
+        select = sqlglot.parse_one(model.sql, read="duckdb").find(exp.Select)
+    except Exception as exc:
+        logger.warning("transform lineage: {} failed to parse: {}", model.target, exc)
+        return []
+    if select is None:
+        return []
+
+    edges: list[LineageEdge] = []
+    for projection in select.expressions:
+        col_name = projection.alias_or_name
+        if not col_name:
+            continue
+        try:
+            root = _sqlglot_lineage(col_name, model.sql, dialect="duckdb")
+        except Exception as exc:
+            logger.warning(
+                "transform lineage: {}.{} unresolved: {}", model.target, col_name, exc
+            )
+            continue
+        for node in root.walk():
+            if node.downstream or not isinstance(node.source, exp.Table):
+                continue  # only true leaves backed by a real table are sources
+            table = ".".join(p for p in (node.source.db, node.source.name) if p)
+            if not table:
+                continue
+            source_column = node.name.rsplit(".", 1)[-1]
+            edges.append(LineageEdge(model.target, col_name, table, source_column))
+    return edges

--- a/src/cdsci/lake/transform/models.py
+++ b/src/cdsci/lake/transform/models.py
@@ -1,0 +1,44 @@
+"""``cdsci.lake.transform.models`` — SQL-file model discovery (ADR-0015 decision 1).
+
+A model is one ``*.sql`` file. Its path relative to the models root *is* its
+target table: ``ref/id_crosswalk.sql`` -> ``ref.id_crosswalk``. The file body is
+the ``SELECT`` the runner wraps in ``CREATE OR REPLACE TABLE {target} AS (...)``
+— no macro DSL, no per-model config file, so ``sqlglot`` can parse the body
+directly for :mod:`.graph` and :mod:`.lineage`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Model:
+    """One SQL-file transform model, keyed by its ``target`` table name."""
+
+    target: str  # "ref.id_crosswalk" -- catalog-less; the runner prefixes LAKE
+    sql: str  # the file body, stripped -- a SELECT, no leading CREATE
+    path: Path
+
+
+def load_models(models_dir: Path | str) -> dict[str, Model]:
+    """Load every ``*.sql`` file under ``models_dir`` into a ``{target: Model}`` map.
+
+    Raises on a duplicate target (two files mapping to the same table) or an
+    empty file — both are authoring mistakes, not runtime conditions to tolerate.
+    """
+    root = Path(models_dir)
+    models: dict[str, Model] = {}
+    for path in sorted(root.rglob("*.sql")):
+        target = ".".join(path.relative_to(root).with_suffix("").parts)
+        if target in models:
+            raise ValueError(
+                f"duplicate transform model target {target!r}: "
+                f"{models[target].path} and {path}"
+            )
+        sql = path.read_text().strip()
+        if not sql:
+            raise ValueError(f"empty transform model: {path}")
+        models[target] = Model(target=target, sql=sql, path=path)
+    return models

--- a/src/cdsci/lake/transform/runner.py
+++ b/src/cdsci/lake/transform/runner.py
@@ -1,0 +1,57 @@
+"""``cdsci.lake.transform.runner`` — execute a model inside ``ops.run`` (ADR-0015 §1/§4).
+
+This is ADR-0013's parked ``rebuild`` verb, scoped to this module only — the EL
+write path (:func:`cdsci.lake.connect.upsert`) stays ``upsert``-only. Reuses
+``ops.run``/``Run.attribute`` exactly as ``upsert`` does today: one
+``lake_ops.run`` row and one self-describing DuckLake snapshot per model.
+"""
+
+from __future__ import annotations
+
+import duckdb
+
+from .. import ops
+from ..connect import LAKE
+from ..log import logger
+from .graph import build_graph, topological_order
+from .models import Model
+
+
+def run_model(con: duckdb.DuckDBPyConnection, model: Model) -> int:
+    """``CREATE OR REPLACE TABLE {LAKE}.{model.target} AS (model.sql)``; returns row count.
+
+    Self-registers ``model.target`` as a ``lake_ops.source`` on every call
+    (cheap delete-then-insert, ADR-0011 §4's "idempotent and self-healing"
+    pattern) — a transform model isn't in the built-in ``SOURCES`` tuple, so
+    without this every run would fall back to unattributed ``<source>:<source>``
+    with a warning.
+    """
+    schema, table = model.target.split(".", 1)
+    target = f"{LAKE}.{model.target}"
+    ops.register_sources(
+        con,
+        writer="cdsci",
+        sources=(
+            ops.Source(
+                model.target, schema, f"transform model: {model.target}",
+                "on-demand", "sql-transform", "internal",
+            ),
+        ),
+    )
+    with ops.run(con, source=model.target, target=target) as r:
+        with r.attribute(table):
+            con.execute(f"CREATE SCHEMA IF NOT EXISTS {LAKE}.{schema};")
+            con.execute(f"CREATE OR REPLACE TABLE {target} AS ({model.sql});")
+        r.rows = con.execute(f"SELECT count(*) FROM {target}").fetchone()[0]
+    return r.rows
+
+
+def run_all(con: duckdb.DuckDBPyConnection, models: dict[str, Model]) -> dict[str, int]:
+    """Run every model in dependency order; return ``{target: row_count}``.
+
+    Order comes from :func:`cdsci.lake.transform.graph.topological_order` — a
+    dependency always runs before anything reading it.
+    """
+    order = topological_order(build_graph(models))
+    logger.info("transform: running {} model(s) in order: {}", len(order), order)
+    return {target: run_model(con, models[target]) for target in order}

--- a/src/cdsci/lake/transform/runner.py
+++ b/src/cdsci/lake/transform/runner.py
@@ -14,6 +14,7 @@ from .. import ops
 from ..connect import LAKE
 from ..log import logger
 from .graph import build_graph, topological_order
+from .lineage import model_lineage
 from .models import Model
 
 
@@ -43,7 +44,28 @@ def run_model(con: duckdb.DuckDBPyConnection, model: Model) -> int:
             con.execute(f"CREATE SCHEMA IF NOT EXISTS {LAKE}.{schema};")
             con.execute(f"CREATE OR REPLACE TABLE {target} AS ({model.sql});")
         r.rows = con.execute(f"SELECT count(*) FROM {target}").fetchone()[0]
+    _log_lineage(model)
     return r.rows
+
+
+def _log_lineage(model: Model) -> None:
+    """Log every best-effort lineage edge for ``model`` (ADR-0015 §2).
+
+    No ``lake_ops.lineage`` table exists yet (ADR-0014) to persist these into
+    — the log line *is* the record for now, so every edge is logged, not a
+    summary count. Lineage computation can't fail a run (see
+    :func:`cdsci.lake.transform.lineage.model_lineage`'s own try/except), so
+    this always runs after a successful write.
+    """
+    bound = logger.bind(ctx=f"transform:{model.target}")
+    edges = model_lineage(model)
+    for edge in edges:
+        bound.info(
+            "lineage: {}.{} <- {}.{}",
+            edge.target, edge.target_column, edge.source_table, edge.source_column,
+        )
+    if not edges:
+        bound.info("lineage: no resolvable edges")
 
 
 def run_all(con: duckdb.DuckDBPyConnection, models: dict[str, Model]) -> dict[str, int]:

--- a/src/cdsci/lake/transform/targets.py
+++ b/src/cdsci/lake/transform/targets.py
@@ -11,7 +11,6 @@ have yet (tracked separately, not in scope for ADR-0015's first pass).
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
@@ -39,7 +38,11 @@ class Target:
       source table's own name).
     * ``lake_table`` — ``{}``; a no-op, the model's own write already *is* the
       publish (named for symmetry — a model can list it as a target explicitly).
-    * ``iceberg`` — ``{"endpoint", "token_env", "catalog", "namespace", "table"}``.
+    * ``iceberg`` — ``{"endpoint", "token", "catalog", "namespace", "table"}``.
+      ``token`` is the already-resolved secret — resolving it from env/GSM is
+      the caller's job (matching ``Settings``' role elsewhere in this repo),
+      not this module's; keeps ``_publish_iceberg`` testable without mutating
+      process environment.
     """
 
     type: Literal["parquet", "duckdb", "lake_table", "iceberg"]
@@ -115,8 +118,9 @@ def _publish_iceberg(con: duckdb.DuckDBPyConnection, source_table: str, config: 
     live in production for ``bioc-on-ice`` (ADR-0015).
     """
     con.execute("INSTALL iceberg; LOAD iceberg;")
-    token = os.environ[config["token_env"]]
-    con.execute("CREATE OR REPLACE SECRET _publish_ice (TYPE ICEBERG, TOKEN ?);", [token])
+    con.execute(
+        "CREATE OR REPLACE SECRET _publish_ice (TYPE ICEBERG, TOKEN ?);", [config["token"]]
+    )
     con.execute(
         f"ATTACH '{config['catalog']}' AS _publish_ice_cat "
         f"(TYPE ICEBERG, ENDPOINT '{config['endpoint']}', SECRET _publish_ice);"

--- a/src/cdsci/lake/transform/targets.py
+++ b/src/cdsci/lake/transform/targets.py
@@ -1,0 +1,139 @@
+"""``cdsci.lake.transform.targets`` — reverse-ETL adapters (ADR-0015 decision 3).
+
+A target is config, not code: ``{"type": "parquet" | "duckdb" | "lake_table" |
+"iceberg", ...}``. DuckDB stays the sole execution engine — native Parquet,
+native DuckDB ``ATTACH``, the ``iceberg`` extension through an attached REST
+catalog (icegate). ``postgres`` is deliberately absent — omicidx's existing
+reverse-ETL does zero-downtime A/B-slot table swaps with per-table hardcoded
+DDL, which needs a declarative DDL/column-mapping design this module doesn't
+have yet (tracked separately, not in scope for ADR-0015's first pass).
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+import duckdb
+
+from ..log import logger
+
+
+def _mkparent(path: str) -> None:
+    """Create a local path's parent dir; a no-op for remote (``s3://``) paths."""
+    if "://" not in path:
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+
+
+@dataclass(frozen=True)
+class Target:
+    """One reverse-ETL publish target for a model's output table.
+
+    ``config`` shape by ``type``:
+
+    * ``parquet`` — ``{"path": "s3://.../v{date}/t.parquet", "latest_path": "...latest/t.parquet"}``
+      (``latest_path`` optional).
+    * ``duckdb`` — ``{"path": "...", "table": "name"}`` (``table`` defaults to the
+      source table's own name).
+    * ``lake_table`` — ``{}``; a no-op, the model's own write already *is* the
+      publish (named for symmetry — a model can list it as a target explicitly).
+    * ``iceberg`` — ``{"endpoint", "token_env", "catalog", "namespace", "table"}``.
+    """
+
+    type: Literal["parquet", "duckdb", "lake_table", "iceberg"]
+    config: dict[str, Any] = field(default_factory=dict)
+
+
+def publish(
+    con: duckdb.DuckDBPyConnection, source_table: str, target: Target, *, date: str
+) -> None:
+    """Publish ``source_table`` (a catalog-qualified lake table) to ``target``.
+
+    ``date`` is a caller-supplied stamp (the ``parquet`` dated-copy pattern) —
+    passed in rather than computed here, so this function stays pure with
+    respect to wall-clock time.
+    """
+    if target.type == "parquet":
+        _publish_parquet(con, source_table, target.config, date)
+    elif target.type in ("duckdb", "lake_table"):
+        _publish_duckdb(con, source_table, target.config)
+    elif target.type == "iceberg":
+        _publish_iceberg(con, source_table, target.config)
+    else:
+        raise ValueError(f"unknown reverse-ETL target type: {target.type!r}")
+
+
+def _publish_parquet(
+    con: duckdb.DuckDBPyConnection, source_table: str, config: dict, date: str
+) -> None:
+    """Dated copy + re-derived ``latest`` — ports omicidx's ``parquet_export`` pattern.
+
+    Writes the dated, immutable copy first, then re-derives ``latest`` by
+    *reading that dated Parquet back* rather than a server-side bucket copy —
+    R2 flakes on multi-GB server-side copies (the reason omicidx's
+    ``parquet_export`` does this; found in ADR-0015 wayfinding).
+    """
+    dated = config["path"].format(date=date)
+    _mkparent(dated)
+    con.execute(f"COPY (SELECT * FROM {source_table}) TO '{dated}' (FORMAT parquet);")
+    logger.info("transform: published {} -> {}", source_table, dated)
+    latest = config.get("latest_path")
+    if latest:
+        _mkparent(latest)
+        con.execute(
+            f"COPY (SELECT * FROM read_parquet('{dated}')) TO '{latest}' (FORMAT parquet);"
+        )
+        logger.info("transform: re-derived latest {} -> {}", dated, latest)
+
+
+def _publish_duckdb(con: duckdb.DuckDBPyConnection, source_table: str, config: dict) -> None:
+    """Copy into a target DuckDB file, or a no-op when the target IS the lake (``lake_table``)."""
+    path = config.get("path")
+    if not path:
+        return  # lake_table: the model's own CREATE OR REPLACE already is the publish
+    _mkparent(path)
+    con.execute(f"ATTACH '{path}' AS _publish_target;")
+    try:
+        table = config.get("table", source_table.rsplit(".", 1)[-1])
+        con.execute(
+            f"CREATE OR REPLACE TABLE _publish_target.{table} AS SELECT * FROM {source_table};"
+        )
+        logger.info("transform: published {} -> {}::{}", source_table, path, table)
+    finally:
+        con.execute("DETACH _publish_target;")
+
+
+def _publish_iceberg(con: duckdb.DuckDBPyConnection, source_table: str, config: dict) -> None:
+    """CREATE-if-absent + full-refresh MERGE, not a literal ``CREATE OR REPLACE`` passthrough.
+
+    DuckDB's Iceberg ``UPDATE``/``DELETE`` are merge-on-read (positional
+    deletes) only — ``CREATE OR REPLACE TABLE`` is not an Iceberg write
+    primitive. A full-table refresh is create-if-absent, then delete-all +
+    insert-all. Writes through an attached REST catalog — icegate, already
+    live in production for ``bioc-on-ice`` (ADR-0015).
+    """
+    con.execute("INSTALL iceberg; LOAD iceberg;")
+    token = os.environ[config["token_env"]]
+    con.execute("CREATE OR REPLACE SECRET _publish_ice (TYPE ICEBERG, TOKEN ?);", [token])
+    con.execute(
+        f"ATTACH '{config['catalog']}' AS _publish_ice_cat "
+        f"(TYPE ICEBERG, ENDPOINT '{config['endpoint']}', SECRET _publish_ice);"
+    )
+    try:
+        namespace, table = config["namespace"], config["table"]
+        con.execute(f"CREATE SCHEMA IF NOT EXISTS _publish_ice_cat.{namespace};")
+        full = f"_publish_ice_cat.{namespace}.{table}"
+        exists = con.execute(
+            "SELECT 1 FROM information_schema.tables "
+            "WHERE table_catalog = ? AND table_schema = ? AND table_name = ?",
+            ["_publish_ice_cat", namespace, table],
+        ).fetchone()
+        if exists is None:
+            con.execute(f"CREATE TABLE {full} AS SELECT * FROM {source_table} LIMIT 0;")
+        con.execute(f"DELETE FROM {full};")
+        con.execute(f"INSERT INTO {full} SELECT * FROM {source_table};")
+        logger.info("transform: published {} -> iceberg {}", source_table, full)
+    finally:
+        con.execute("DETACH _publish_ice_cat;")

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,6 +1,6 @@
 import os
 import sys
-import pytest
+
 from fastapi.testclient import TestClient
 
 # Ensure backend and src are in python path

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,0 +1,152 @@
+"""Offline tests for ``cdsci.lake.transform`` (ADR-0015).
+
+Exercise model discovery, the dependency graph/topo sort, model execution
+against a local DuckLake, and the parquet/duckdb reverse-ETL adapters. No
+network, no Postgres — the ``iceberg`` adapter needs a live REST catalog and
+is exercised only by manual smoke test (targets.py's docstring notes this).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import duckdb
+import pytest
+
+from cdsci.lake import Settings, lake_connect
+from cdsci.lake.transform.graph import build_graph, topological_order
+from cdsci.lake.transform.models import Model, load_models
+from cdsci.lake.transform.runner import run_all, run_model
+from cdsci.lake.transform.targets import Target, publish
+
+
+@pytest.fixture
+def lake_settings(tmp_path: Path) -> Settings:
+    return Settings(storage_base_uri=f"file://{tmp_path / 'lake'}")
+
+
+@pytest.fixture
+def models_dir(tmp_path: Path) -> Path:
+    root = tmp_path / "models"
+    (root / "a").mkdir(parents=True)
+    (root / "a" / "t1.sql").write_text("SELECT 1 AS x, 'a' AS label")
+    (root / "a" / "t2.sql").write_text("SELECT x * 2 AS y FROM lake.a.t1")
+    return root
+
+
+def test_load_models_derives_target_from_path(models_dir: Path):
+    models = load_models(models_dir)
+    assert set(models) == {"a.t1", "a.t2"}
+    assert models["a.t1"].sql == "SELECT 1 AS x, 'a' AS label"
+
+
+def test_load_models_rejects_empty_file(tmp_path: Path):
+    (tmp_path / "empty.sql").write_text("   ")
+    with pytest.raises(ValueError, match="empty transform model"):
+        load_models(tmp_path)
+
+
+def test_graph_and_topological_order(models_dir: Path):
+    models = load_models(models_dir)
+    graph = build_graph(models)
+    assert graph == {"a.t1": set(), "a.t2": {"a.t1"}}
+    assert topological_order(graph) == ["a.t1", "a.t2"]
+
+
+def test_topological_order_raises_on_cycle():
+    graph = {"a": {"b"}, "b": {"a"}}
+    with pytest.raises(ValueError, match="cycle"):
+        topological_order(graph)
+
+
+def test_unresolved_reference_is_a_leaf_not_a_dependency(tmp_path: Path):
+    """A read_parquet(...)/external-table ref never matches a known model target."""
+    (tmp_path / "t.sql").write_text("SELECT * FROM read_parquet('s3://bucket/f.parquet')")
+    models = load_models(tmp_path)
+    assert build_graph(models) == {"t": set()}
+
+
+def test_run_model_creates_table_and_records_run(lake_settings: Settings):
+    con = lake_connect(lake_settings)
+    try:
+        model = Model("xf.t1", "SELECT 1 AS x, 'a' AS label", Path("xf/t1.sql"))
+        rows = run_model(con, model)
+        assert rows == 1
+        assert con.execute("SELECT * FROM lake.xf.t1").fetchall() == [(1, "a")]
+
+        run_row = con.execute(
+            "SELECT source, status, rows_after FROM ops.lake_ops.run WHERE source = 'xf.t1'"
+        ).fetchone()
+        assert run_row == ("xf.t1", "success", 1)
+        # The model self-registered as a lake_ops.source (not in the built-in SOURCES).
+        assert con.execute(
+            "SELECT writer FROM ops.lake_ops.source WHERE name = 'xf.t1'"
+        ).fetchone() == ("cdsci",)
+    finally:
+        con.close()
+
+
+def test_run_model_is_a_real_replace_not_upsert(lake_settings: Settings):
+    """CREATE OR REPLACE — a second run with different data fully replaces, no merge."""
+    con = lake_connect(lake_settings)
+    try:
+        model = Model("xf.t1", "SELECT * FROM (VALUES (1),(2)) v(x)", Path("xf/t1.sql"))
+        run_model(con, model)
+        model2 = Model("xf.t1", "SELECT * FROM (VALUES (9)) v(x)", Path("xf/t1.sql"))
+        run_model(con, model2)
+        assert con.execute("SELECT * FROM lake.xf.t1").fetchall() == [(9,)]
+    finally:
+        con.close()
+
+
+def test_run_all_respects_dependency_order(lake_settings: Settings, models_dir: Path):
+    con = lake_connect(lake_settings)
+    try:
+        models = load_models(models_dir)
+        results = run_all(con, models)
+        assert results == {"a.t1": 1, "a.t2": 1}
+        assert con.execute("SELECT * FROM lake.a.t2").fetchall() == [(2,)]
+    finally:
+        con.close()
+
+
+def test_publish_parquet_dated_and_latest(lake_settings: Settings, tmp_path: Path):
+    con = lake_connect(lake_settings)
+    try:
+        con.execute("CREATE SCHEMA lake.a; CREATE TABLE lake.a.t1 AS SELECT 1 AS x")
+        target = Target(
+            "parquet",
+            {
+                "path": str(tmp_path / "pub" / "v{date}" / "t1.parquet"),
+                "latest_path": str(tmp_path / "pub" / "latest" / "t1.parquet"),
+            },
+        )
+        publish(con, "lake.a.t1", target, date="2026-08-07")
+        dated = duckdb.sql(
+            f"SELECT * FROM read_parquet('{tmp_path}/pub/v2026-08-07/t1.parquet')"
+        ).fetchall()
+        latest = duckdb.sql(
+            f"SELECT * FROM read_parquet('{tmp_path}/pub/latest/t1.parquet')"
+        ).fetchall()
+        assert dated == [(1,)]
+        assert latest == [(1,)]
+    finally:
+        con.close()
+
+
+def test_publish_duckdb_and_lake_table_noop(lake_settings: Settings, tmp_path: Path):
+    con = lake_connect(lake_settings)
+    try:
+        con.execute("CREATE SCHEMA lake.a; CREATE TABLE lake.a.t1 AS SELECT 1 AS x")
+        mart_path = tmp_path / "mart.duckdb"
+        publish(con, "lake.a.t1", Target("duckdb", {"path": str(mart_path)}), date="2026-08-07")
+        mart = duckdb.connect(str(mart_path))
+        try:
+            assert mart.execute("SELECT * FROM t1").fetchall() == [(1,)]
+        finally:
+            mart.close()
+
+        # lake_table is a documented no-op: the model's own write already is the publish.
+        publish(con, "lake.a.t1", Target("lake_table"), date="2026-08-07")
+    finally:
+        con.close()

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -86,6 +86,33 @@ def test_run_model_creates_table_and_records_run(lake_settings: Settings):
         con.close()
 
 
+def test_run_model_logs_lineage(lake_settings: Settings):
+    """run_model logs every resolvable lineage edge -- no lake_ops.lineage table
+    yet (ADR-0014) to persist into, so the log line is the only record today."""
+    from loguru import logger as loguru_logger
+
+    con = lake_connect(lake_settings)
+    try:
+        con.execute(
+            "CREATE SCHEMA lake.src; "
+            "CREATE TABLE lake.src.t AS SELECT 1 AS id, 'x' AS val"
+        )
+        model = Model("xf.derived", "SELECT id, val FROM lake.src.t", Path("xf/derived.sql"))
+
+        lines: list[str] = []
+        sink_id = loguru_logger.add(lambda msg: lines.append(msg.record["message"]), level="INFO")
+        try:
+            run_model(con, model)
+        finally:
+            loguru_logger.remove(sink_id)
+
+        lineage_lines = [line for line in lines if line.startswith("lineage:")]
+        assert "lineage: xf.derived.id <- src.t.id" in lineage_lines
+        assert "lineage: xf.derived.val <- src.t.val" in lineage_lines
+    finally:
+        con.close()
+
+
 def test_run_model_is_a_real_replace_not_upsert(lake_settings: Settings):
     """CREATE OR REPLACE — a second run with different data fully replaces, no merge."""
     con = lake_connect(lake_settings)

--- a/uv.lock
+++ b/uv.lock
@@ -56,6 +56,10 @@ ingest = [
     { name = "tenacity" },
     { name = "typer" },
 ]
+transform = [
+    { name = "sqlglot" },
+    { name = "typer" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -73,12 +77,14 @@ requires-dist = [
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "pydantic-settings", specifier = ">=2.14.1" },
     { name = "pytz", marker = "extra == 'ingest'", specifier = ">=2025.1" },
+    { name = "sqlglot", marker = "extra == 'transform'", specifier = ">=27" },
     { name = "tenacity", specifier = ">=9.1.4" },
     { name = "tenacity", marker = "extra == 'ingest'", specifier = ">=9.1.4" },
     { name = "typer", marker = "extra == 'ingest'", specifier = ">=0.26.7" },
+    { name = "typer", marker = "extra == 'transform'", specifier = ">=0.26.7" },
     { name = "uvicorn", marker = "extra == 'dashboard'", specifier = ">=0.30.0" },
 ]
-provides-extras = ["ingest", "dashboard"]
+provides-extras = ["ingest", "dashboard", "transform"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -508,6 +514,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "sqlglot"
+version = "30.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/fb/c43bfdc662bd6fcdf93158f9239b975ac01b775cfcb56015913fee9b95e2/sqlglot-30.15.0.tar.gz", hash = "sha256:fe5412f4da61075f532d3de2482144bf7139028980a37bbd79fb016c49dc2dbe", size = 5973319, upload-time = "2026-08-04T17:37:12.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/28/f1e99aca0c23e2406dc8727555476647d58c2d6315d7d8101dffbb2cbc0f/sqlglot-30.15.0-py3-none-any.whl", hash = "sha256:594da0bc9d020edfb9982fd56b61dc93483cb24edca5ed1b3bb17937ba9b59bc", size = 731813, upload-time = "2026-08-04T17:37:11.48Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements `cdsci.lake.transform` per [ADR-0015](docs/adr/0015-transform-and-reverse-etl-layer.md): SQL-file models, sqlglot for dependency-graph + best-effort lineage only (no orchestration DSL), DuckDB as the sole execution engine, config-driven reverse-ETL targets. Closes #20 (and sub-issues #21-#29, already closed individually as each landed).

Based on `docs/metadata-lineage-contract` (#19) rather than `main`, since ADR-0014/0015 live there and haven't merged to main yet — this stacks on top.

## What's in

- `models.py` / `graph.py` — SQL-file discovery (file path encodes target table) + sqlglot table-ref extraction + Kahn's-algorithm topo sort. Unresolved refs (external tables, `read_parquet(...)`) are leaves, not errors.
- `lineage.py` — best-effort column lineage via `sqlglot.lineage`, computed per model.
- `runner.py` — `CREATE OR REPLACE` execution reusing `ops.run`/`Run.attribute` exactly like `upsert` (ADR-0013's parked `rebuild` verb, scoped to this module only). Every run now also logs its lineage edges (`lineage: target.col <- table.col`) — no `lake_ops.lineage` table exists yet (ADR-0014) to persist into, so the log line is the record for now.
- `targets.py` — config-driven reverse-ETL adapters: `parquet` (ports omicidx's dated-copy + re-derived-`latest` pattern), `duckdb`/`lake_table`, `iceberg` (via an attached REST catalog — icegate). `postgres` deliberately out of scope (needs a declarative DDL/column-mapping design given omicidx's existing A/B-slot-swap pattern).
- CLI (`python -m cdsci.lake.transform`) — `list` / `graph` / `run` / `run-all`.
- Pilot model `models/ref/id_crosswalk.sql` — PMID↔DOI↔PMCID↔core_project_num↔NCT, **materialized against production**: 40,643,609 rows. Coverage: 32.5M with DOI, 6.5M with PMCID, 3.2M linked to an NIH grant, 774,907 linked to a clinical trial.
- `ci.yml` — was only `uv sync --extra ingest`, so neither this PR's tests nor #19's `test_dashboard.py` could even collect (missing sqlglot/typer/fastapi). Now `--all-extras`. Also fixed a pre-existing ruff lint in `test_dashboard.py` blocking a clean `ruff check`.

## Verification

- 11 new offline tests (models/graph/runner/targets/lineage-logging), full suite 56 passed / 3 skipped, ruff clean.
- Reviewed with the `codebase-design` skill: fixed a leaked implementation-detail function (`model_dependencies` → private) and an untestable direct `os.environ` read in the iceberg adapter (now takes an already-resolved token).
- `iceberg` adapter is written per icegate's documented DuckDB usage but **not yet verified against a live catalog** — a manual smoke test script (`scripts/smoketest_icegate.py`) is included for that, pending a run against `bioc-on-ice`'s icegate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)