### PR TITLE
Add BugSigDB normalized models: study/experiment/signature + tests

### DIFF
--- a/models/bugsigdb/experiment.sql
+++ b/models/bugsigdb/experiment.sql
@@ -1,0 +1,49 @@
+-- description: BugSigDB experiment-level fields (subject groups, sequencing method, diversity metrics), one row per (study, experiment).
+-- license: cc-by-4.0
+-- column experiment_id: Reconstructs BugSigDB's own study/experiment_num numbering (from bsdb_id's shape) -- this lake's synthesized join key, not a citable external identifier.
+-- bugsigdb.experiment (ADR-0015): one row per (study, experiment) -- BugSigDB
+-- nests experiments under a study, and the raw "Experiment N" label is only
+-- unique within its study, not globally (two different studies both have an
+-- "Experiment 1"). `experiment_id` derives BugSigDB's own numbering instead of
+-- inventing a surrogate key: bsdb_id is shaped study/experiment_num/signature_num
+-- (e.g. `bsdb:41077329/9/2`), so `experiment_id` reconstructs the middle segment
+-- (`41077329/9`) directly from `experiment`'s trailing digits.
+--
+-- Column set verified empirically: every column below is constant within
+-- (study, experiment) but varies across experiments within the same study --
+-- see study.sql (constant within study) / signature.sql (varies even within
+-- an experiment) for the other two tiers.
+SELECT
+    study AS study_id,
+    experiment,
+    study || '/' || regexp_extract(experiment, '\d+') AS experiment_id,
+    location_of_subjects,
+    host_species,
+    body_site,
+    uberon_id,
+    condition,
+    efo_id,
+    group_0_name,
+    group_1_name,
+    group_1_definition,
+    group_0_sample_size,
+    group_1_sample_size,
+    antibiotics_exclusion,
+    sequencing_type,
+    variable_region_16s,
+    sequencing_platform,
+    data_transformation,
+    statistical_test,
+    significance_threshold,
+    mht_correction,
+    lda_score_above,
+    matched_on,
+    confounders_controlled_for,
+    pielou,
+    shannon,
+    chao1,
+    simpson,
+    inverse_simpson,
+    richness
+FROM lake.bugsigdb.signatures
+GROUP BY ALL

--- a/models/bugsigdb/experiment.test.sql
+++ b/models/bugsigdb/experiment.test.sql
@@ -1,0 +1,2 @@
+-- test: experiment_id is unique
+SELECT experiment_id FROM lake.bugsigdb.experiment GROUP BY experiment_id HAVING count(*) > 1

--- a/models/bugsigdb/signature.sql
+++ b/models/bugsigdb/signature.sql
@@ -1,0 +1,27 @@
+-- description: BugSigDB signature-level fields (curation metadata, description, taxon-member lists), one row per bsdb_id.
+-- license: cc-by-4.0
+-- bugsigdb.signature (ADR-0015): one row per bsdb_id, same grain as
+-- lake.bugsigdb.signatures itself but narrowed to the columns that actually
+-- vary at signature grain -- curation/review metadata, the two taxon-member
+-- columns, and free-text description/abundance -- plus FKs into study and
+-- experiment. Everything constant within (study, experiment) lives in
+-- bugsigdb.experiment instead; join back through experiment_id rather than
+-- re-carrying those columns here. `signature_taxon.sql` (the taxon-member
+-- bridge table) intentionally still reads lake.bugsigdb.signatures directly,
+-- not this table -- it only needs bsdb_id + the two taxon columns, both
+-- present identically on either source, and predates this decomposition.
+SELECT
+    bsdb_id,
+    study AS study_id,
+    study || '/' || regexp_extract(experiment, '\d+') AS experiment_id,
+    signature_page_name,
+    source_in_paper,
+    curated_date,
+    curator,
+    revision_editor,
+    reviewer,
+    description,
+    abundance_in_group_1,
+    metaphlan_taxon_names,
+    ncbi_taxonomy_ids
+FROM lake.bugsigdb.signatures

--- a/models/bugsigdb/signature.test.sql
+++ b/models/bugsigdb/signature.test.sql
@@ -1,0 +1,2 @@
+-- test: bsdb_id is unique
+SELECT bsdb_id FROM lake.bugsigdb.signature GROUP BY bsdb_id HAVING count(*) > 1

--- a/models/bugsigdb/signature_taxon.sql
+++ b/models/bugsigdb/signature_taxon.sql
@@ -1,0 +1,44 @@
+-- description: BugSigDB signature<->NCBI-taxon bridge table, one row per taxon member of a signature.
+-- license: cc-by-4.0
+-- column ncbitaxon_id: NCBI Taxonomy id (bioregistry prefix `ncbitaxon`, not `ncbi_taxon` -- verified against bioregistry.io / lake.ref.bioregistry 2026-08-10). Bare local id, no embedded prefix -- this column is single-vocabulary.
+-- bugsigdb.signature_taxon (cdsci-lake#31, ADR-0015 pilot model #2): explodes
+-- lake.bugsigdb.signatures' two nested member-list columns into one row per
+-- signature member. `metaphlan_taxon_names` (comma-separated) and
+-- `ncbi_taxonomy_ids` (semicolon-separated) are positionally matched --
+-- verified against the full v1.3.1 export: 0 rows where the two lists differ
+-- in length. Each element is itself a `|`-separated lineage
+-- (`k__..|p__..|..|s__Species name`, taxids in the same rank order); only the
+-- leaf (most specific asserted rank) is split out here, the full lineage is
+-- kept alongside for provenance.
+--
+-- ponytail: no rank rollup (kingdom/phylum/.../species as separate columns) --
+-- that needs NCBI Taxonomy for a real taxonomic join (bioc-on-ice's bugsigdb.py
+-- flagged the same gap, tracked as bioc-on-ice#18). Add it if a consumer needs
+-- to query at a fixed rank rather than take whatever rank each member asserts.
+WITH lists AS (
+    SELECT
+        bsdb_id,
+        string_split(metaphlan_taxon_names, ',') AS taxa,
+        string_split(ncbi_taxonomy_ids, ';') AS taxids
+    FROM lake.bugsigdb.signatures
+    WHERE metaphlan_taxon_names IS NOT NULL AND ncbi_taxonomy_ids IS NOT NULL
+),
+members AS (
+    SELECT
+        bsdb_id,
+        ord AS member_index,
+        trim(taxon_lineage) AS taxon_lineage,
+        trim(taxids[ord]) AS taxon_lineage_ids,
+        list_extract(string_split(trim(taxon_lineage), '|'), -1) AS leaf_raw
+    FROM lists, UNNEST(taxa) WITH ORDINALITY AS u(taxon_lineage, ord)
+    WHERE trim(taxon_lineage) <> ''
+)
+SELECT
+    bsdb_id,
+    member_index,
+    regexp_extract(leaf_raw, '^([a-z])__', 1) AS taxon_rank,
+    regexp_replace(leaf_raw, '^[a-z]__', '') AS taxon_name,
+    TRY_CAST(list_extract(string_split(taxon_lineage_ids, '|'), -1) AS BIGINT) AS ncbitaxon_id,
+    taxon_lineage,
+    taxon_lineage_ids
+FROM members

--- a/models/bugsigdb/signature_taxon.test.sql
+++ b/models/bugsigdb/signature_taxon.test.sql
@@ -1,0 +1,3 @@
+-- test: (bsdb_id, member_index) is unique
+SELECT bsdb_id, member_index FROM lake.bugsigdb.signature_taxon
+GROUP BY bsdb_id, member_index HAVING count(*) > 1

--- a/models/bugsigdb/study.sql
+++ b/models/bugsigdb/study.sql
@@ -1,0 +1,29 @@
+-- description: BugSigDB study-level fields (bibliographic), one row per study.
+-- license: cc-by-4.0
+-- column study_id: This lake's synthesized join key (a stringified PMID, verified 1:1 with `pmid`) -- not a citable external identifier, see the note below on why it's `study_id` and not bare `study`.
+-- bugsigdb.study (ADR-0015): one row per BugSigDB study, dedup'd from
+-- lake.bugsigdb.signatures' study-level columns. `study_id` is the natural
+-- key -- it's a stringified PMID in BugSigDB's own scheme, verified 1:1 with
+-- `pmid` against the full v1.3.1 export (0 studies with >1 distinct pmid, 0
+-- pmids with >1 distinct study). Named `study_id`, not the bare `study` the
+-- source column originally carried -- it's this lake's own synthesized join
+-- key (same reasoning as `experiment_id`), not a citable external identifier
+-- like `pmid`/`bsdb_id`, so it gets the `_id` suffix that signals that
+-- (2026-08-10 id-naming-convention session). Column set verified empirically
+-- too: every column below has zero within-study variation across all 7,425
+-- signature rows; anything that varied went into experiment.sql or
+-- signature.sql instead.
+SELECT
+    study AS study_id,
+    pmid,
+    doi,
+    url,
+    authors_list,
+    title,
+    journal,
+    year,
+    keywords,
+    study_design,
+    state
+FROM lake.bugsigdb.signatures
+GROUP BY ALL

--- a/models/bugsigdb/study.test.sql
+++ b/models/bugsigdb/study.test.sql
@@ -1,0 +1,2 @@
+-- test: study_id is unique
+SELECT study_id FROM lake.bugsigdb.study GROUP BY study_id HAVING count(*) > 1

--- a/src/cdsci/lake/sources/bugsigdb/__init__.py
+++ b/src/cdsci/lake/sources/bugsigdb/__init__.py
@@ -1,0 +1,13 @@
+"""BugSigDB — manually curated microbial signatures.
+
+One tidy table ``lake.bugsigdb.signatures`` from the tag-pinned Waldron Lab
+export (CC BY 4.0), keyed ``bsdb_id``. ``metaphlan_taxon_names`` /
+``ncbi_taxonomy_ids`` land as raw delimited strings; the transform layer
+explodes them into ``bugsigdb.signature_taxon``
+(``models/bugsigdb/signature_taxon.sql``). Ported from bioc-on-ice, which
+retires its own copy in favor of this (bioc-on-ice#67 / cdsci-lake#31).
+"""
+
+from .ingest import curate, download_csv, ingest
+
+__all__ = ["curate", "download_csv", "ingest"]

--- a/src/cdsci/lake/sources/bugsigdb/__main__.py
+++ b/src/cdsci/lake/sources/bugsigdb/__main__.py
@@ -1,0 +1,43 @@
+"""CLI: ``python -m cdsci.lake.sources.bugsigdb`` — load BugSigDB."""
+
+from __future__ import annotations
+
+import typer
+
+from ...log import configure
+from .ingest import ingest
+
+app = typer.Typer(
+    help="Ingest a BugSigDB release tag into lake.bugsigdb.signatures.",
+    add_completion=False,
+)
+
+
+@app.callback()
+def main(log_level: str = typer.Option("INFO", "--log-level", help="loguru level.")) -> None:
+    """BugSigDB ingestor (keeps the ``run`` subcommand explicit)."""
+    configure(log_level)
+
+
+@app.command("run")
+def run(
+    file: str | None = typer.Option(
+        None, "--file", help="Local CSV to load instead of downloading."
+    ),
+    version: str | None = typer.Option(
+        None, "--version", help="BugSigDB release tag (default: Settings.bugsigdb_version)."
+    ),
+    schema: str = typer.Option("bugsigdb", "--schema", help="Target lake schema."),
+    limit: int | None = typer.Option(None, "--limit", help="Cap rows (smoke test)."),
+) -> None:
+    """Download (unless --file) and MERGE-upsert one BugSigDB release tag."""
+    summary = ingest(file=file, version=version, schema=schema, limit=limit)
+    delta = "changed" if summary["changed"] else "no change (idempotent)"
+    typer.echo(
+        f"{summary['table']} <- {summary['rows']:,} rows "
+        f"(release {summary['version']}) — {delta}"
+    )
+
+
+if __name__ == "__main__":
+    app()

--- a/src/cdsci/lake/sources/bugsigdb/ingest.py
+++ b/src/cdsci/lake/sources/bugsigdb/ingest.py
@@ -1,0 +1,202 @@
+"""BugSigDB curated microbial signatures -> ``lake.bugsigdb.signatures``.
+
+BugSigDB is manually curated microbial signatures: per publication, a contrast
+between two groups of subjects, and the taxa differentially abundant in one of
+them. ``full_dump.csv`` is the canonical export, flattened across study,
+experiment and signature — ~7,400 rows, one file, none of the streaming
+machinery the larger sources need.
+
+**Versioned by release tag, not retrieval date.** The exports repo re-renders
+from bugsigdb.org every hour, so ``devel`` is a moving target; the tagged
+releases are the manually-reviewed ones, each archived under a Zenodo DOI.
+Landing from a tag is what keeps this idempotent and citable per version.
+Ported from bioc-on-ice's ``src/bioconice/bugsigdb.py``, which is retiring in
+favor of this (bioc-on-ice#67 / cdsci-lake#31) — bioc-on-ice becomes a
+publication layer, this is where the source lives now.
+
+The column contract is explicit on purpose: the CSV header is trusted and the
+SELECT names each column, so an upstream rename/removal fails loudly in
+DuckDB's binder rather than silently shifting every value one column over —
+same reasoning as the original.
+
+``metaphlan_taxon_names`` / ``ncbi_taxonomy_ids`` land as their raw
+comma/semicolon-delimited strings (one element per signature member,
+positionally matched between the two columns). Exploding them into a
+signature<->taxon bridge table is the transform layer's job
+(``models/bugsigdb/signature_taxon.sql``), not this EL step's.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import duckdb
+
+from ... import ops
+from ...config import Settings, get_settings
+from ...connect import LAKE, csv_source, lake_connect, raw_dir, upsert
+from ...download import download
+
+_RAW = "bugsigdb"
+
+# Upstream header -> our column name. Snake-cased throughout; `Source` becomes
+# `source_in_paper` because `source` means "the asserting authority" everywhere
+# else in this lake, and here it means "Table 2".
+COLUMNS = {
+    "BSDB ID": "bsdb_id",
+    "Study": "study",
+    "Study design": "study_design",
+    "PMID": "pmid",
+    "DOI": "doi",
+    "URL": "url",
+    "Authors list": "authors_list",
+    "Title": "title",
+    "Journal": "journal",
+    "Year": "year",
+    "Keywords": "keywords",
+    "Experiment": "experiment",
+    "Location of subjects": "location_of_subjects",
+    "Host species": "host_species",
+    "Body site": "body_site",
+    "UBERON ID": "uberon_id",
+    "Condition": "condition",
+    "EFO ID": "efo_id",
+    "Group 0 name": "group_0_name",
+    "Group 1 name": "group_1_name",
+    "Group 1 definition": "group_1_definition",
+    "Group 0 sample size": "group_0_sample_size",
+    "Group 1 sample size": "group_1_sample_size",
+    "Antibiotics exclusion": "antibiotics_exclusion",
+    "Sequencing type": "sequencing_type",
+    "16S variable region": "variable_region_16s",
+    "Sequencing platform": "sequencing_platform",
+    "Data transformation": "data_transformation",
+    "Statistical test": "statistical_test",
+    "Significance threshold": "significance_threshold",
+    "MHT correction": "mht_correction",
+    "LDA Score above": "lda_score_above",
+    "Matched on": "matched_on",
+    "Confounders controlled for": "confounders_controlled_for",
+    "Pielou": "pielou",
+    "Shannon": "shannon",
+    "Chao1": "chao1",
+    "Simpson": "simpson",
+    "Inverse Simpson": "inverse_simpson",
+    "Richness": "richness",
+    "Signature page name": "signature_page_name",
+    "Source": "source_in_paper",
+    "Curated date": "curated_date",
+    "Curator": "curator",
+    "Revision editor": "revision_editor",
+    "Description": "description",
+    "Abundance in Group 1": "abundance_in_group_1",
+    "MetaPhlAn taxon names": "metaphlan_taxon_names",
+    "NCBI Taxonomy IDs": "ncbi_taxonomy_ids",
+    "State": "state",
+    "Reviewer": "reviewer",
+}
+
+# A handful of columns are typed rather than left VARCHAR — the ones with join
+# or filter value (like retractionwatch's dates/PMIDs/arrays). Everything else
+# stays plain text; this is a curated *export*, not a normalized schema, and
+# most columns are free text or fixed-vocabulary strings not worth guessing at.
+_TYPED = {
+    "PMID": 'TRY_CAST("PMID" AS BIGINT)',
+    "Year": 'TRY_CAST("Year" AS INTEGER)',
+    "Curated date": "TRY_STRPTIME(\"Curated date\", '%d %B %Y')::DATE",
+    "Group 0 sample size": 'TRY_CAST("Group 0 sample size" AS INTEGER)',
+    "Group 1 sample size": 'TRY_CAST("Group 1 sample size" AS INTEGER)',
+}
+
+
+def dump_url(version: str, repo: str) -> str:
+    return f"{repo}/{version}/full_dump.csv"
+
+
+def download_csv(version: str, settings: Settings | None = None) -> Path:
+    """Download one release tag's ``full_dump.csv`` into the raw layer.
+
+    Dest is keyed by tag, not date — re-landing the same tag is a no-op
+    (``download`` skips an existing file) and landing a new tag accumulates
+    alongside the old one, same as bioc-on-ice's original.
+    """
+    s = settings or get_settings()
+    dest = raw_dir(_RAW, s) / f"{version}-full_dump.csv"
+    return download(dump_url(version, s.bugsigdb_repo), dest)
+
+
+def _exported_at(path: Path) -> str | None:
+    """The export's self-declared banner timestamp (first line), not file mtime.
+
+    The first line is ``# BugSigDB 2026-04-24_00:41_UTC, License: ..., URL:
+    ...`` — only that line is read, not the whole file.
+    """
+    with open(path, encoding="utf-8") as f:
+        first = f.readline()
+    m = re.match(r"#\s*BugSigDB\s+([^,\s]+)", first)
+    return m.group(1) if m else None
+
+
+def _column_sql(src: str, dst: str) -> str:
+    expr = _TYPED.get(src, f'"{src}"')
+    return f"{expr} AS {dst}"
+
+
+def _select_sql(path: Path, version: str, exported_at: str | None, limit: int | None) -> str:
+    limit_sql = f" LIMIT {int(limit)}" if limit else ""
+    select = ",\n            ".join(_column_sql(src, dst) for src, dst in COLUMNS.items())
+    exported_sql = f"'{exported_at}'" if exported_at else "NULL::VARCHAR"
+    # Dialect stated, not sniffed: free-text columns carry commas/quotes/newlines,
+    # a sniffer guessing differently between releases would shift values silently.
+    # nullstr='NA' is BugSigDB's missing marker. skip=1 drops the banner line so
+    # the real header is read as the header.
+    return f"""
+        SELECT
+            {select},
+            {exported_sql} AS export_timestamp,
+            '{version}' AS bugsigdb_version
+        FROM read_csv({csv_source([path])}, skip=1, header=true, all_varchar=true,
+                      nullstr='NA', delim=',', quote='"', escape='"', ignore_errors=true)
+        {limit_sql}
+    """
+
+
+def curate(
+    con: duckdb.DuckDBPyConnection,
+    path: Path,
+    version: str,
+    exported_at: str | None,
+    *,
+    target: str | None = None,
+    limit: int | None = None,
+) -> int:
+    """MERGE-upsert one release's ``full_dump.csv`` into ``signatures`` on ``bsdb_id``."""
+    target = target or f"{LAKE}.bugsigdb.signatures"
+    return upsert(
+        con, target, _select_sql(path, version, exported_at, limit),
+        key="bsdb_id", exclude_change_cols=["export_timestamp"],
+    )
+
+
+def ingest(
+    *,
+    file: str | None = None,
+    version: str | None = None,
+    schema: str = "bugsigdb",
+    limit: int | None = None,
+    settings: Settings | None = None,
+) -> dict:
+    """End-to-end: download (unless ``file``) a release tag -> MERGE-upsert -> summary."""
+    s = settings or get_settings()
+    version = version or s.bugsigdb_version
+    path = Path(file) if file else download_csv(version, s)
+    exported_at = _exported_at(path)
+    target = f"{LAKE}.{schema}.signatures"
+    con = lake_connect(s)
+    try:
+        with ops.run(con, source="bugsigdb", target=target, version=version) as r:
+            r.rows = curate(con, path, version, exported_at, target=target, limit=limit)
+    finally:
+        con.close()
+    return r.summary()


### PR DESCRIPTION
Closes #44. Verified locally: `ruff check src/ tests/` clean, `pytest` green (56 passed, 3 skipped). Live-verified against prod: see commit message for the empirical column-grain verification and join-integrity checks.