### PR TITLE
Scheduling pilot: systemd --user timers for retractionwatch + icite

### DIFF
--- a/systemd/icite.service
+++ b/systemd/icite.service
@@ -1,0 +1,27 @@
+# Pilot job #2 for the cdsci-lake systemd scheduling convention -- see
+# monode/infrastructure's SCHEDULING.md for the full pattern this is an
+# instance of.
+[Unit]
+Description=Load the monthly iCite snapshot into lake.icite.metadata
+Documentation=file:///home/davsean/Documents/git/cdsci-lake/docs/design/dashboard_and_scheduling.md
+After=network-online.target
+Wants=network-online.target
+OnFailure=ntfy-notify@%N.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=/home/davsean/Documents/git/cdsci-lake
+EnvironmentFile=/home/davsean/Documents/git/cdsci-lake/.env
+Environment=CU_OPENALEX_LAKE_BACKEND=postgres
+ExecStart=/usr/bin/env uv run python -m cdsci.lake.sources.icite run
+# RuntimeMaxSec= silently has no effect on Type=oneshot (systemd quirk --
+# verified with `systemd-analyze verify`, don't reintroduce it). Use
+# TimeoutStartSec= instead, matching bioc-sync.service's precedent. A
+# no-op idempotent check finishes in ~20s, but a real new monthly
+# snapshot is a large figshare download + ~40M-row MERGE -- give it real
+# headroom rather than false-alarming on a big-but-healthy run.
+TimeoutStartSec=10800
+Nice=10
+
+[Install]
+WantedBy=default.target

--- a/systemd/icite.timer
+++ b/systemd/icite.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Monthly iCite snapshot load (source cadence: monthly)
+
+[Timer]
+OnCalendar=monthly
+RandomizedDelaySec=3600
+# icite's actual release day within the month drifts; idempotent MERGE
+# means firing early and finding "no change" costs nothing, so no need to
+# get clever about timing -- just make sure a missed month is caught up.
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/systemd/notify-failure.sh
+++ b/systemd/notify-failure.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Posts a failure alert to the shared cdsci-lake-ops ntfy topic. Invoked by
+# ntfy-notify@%N.service (see that unit) with the failing unit's name as $1.
+#
+# The token is fetched from GSM at call time and never written to disk --
+# same "secrets always come from GSM" rule this repo already follows for
+# R2/Postgres creds (see cdsci.lake.config). See monode/infrastructure's
+# SCHEDULING.md for the full convention this script is part of.
+set -euo pipefail
+
+unit="${1:?usage: notify-failure.sh <unit-name>}"
+token=$(gcloud secrets versions access latest \
+  --secret=cdsci-ntfy-lake-ops-service-token --project=cdsci-infra)
+
+curl -fsS -X POST "https://ntfy.cancerdatasci.org/cdsci-lake-ops" \
+  -H "Authorization: Bearer ${token}" \
+  -H "Title: cdsci-lake job failed: ${unit}" \
+  -H "Priority: high" \
+  -H "Tags: rotating_light" \
+  -d "systemd unit ${unit} failed on $(hostname). journalctl --user -u ${unit} for detail."

--- a/systemd/ntfy-notify@.service
+++ b/systemd/ntfy-notify@.service
@@ -1,0 +1,13 @@
+# Shared failure handler for every cdsci-lake scheduled job. A job's
+# .service unit points at this via `OnFailure=ntfy-notify@%N.service`
+# (see retractionwatch.service) -- %N is the failing unit's own name with
+# .service stripped, so the instance becomes ntfy-notify@retractionwatch,
+# not a doubled suffix. Same pattern as bioc-site's bioc-notify@.service,
+# swapped from "file a GitHub issue" to "POST to ntfy" as the channel.
+[Unit]
+Description=Report failure of %i to the shared cdsci-lake-ops ntfy topic
+
+[Service]
+Type=oneshot
+WorkingDirectory=/home/davsean/Documents/git/cdsci-lake/systemd
+ExecStart=/home/davsean/Documents/git/cdsci-lake/systemd/notify-failure.sh %i.service

--- a/systemd/retractionwatch.service
+++ b/systemd/retractionwatch.service
@@ -1,0 +1,31 @@
+# Pilot job #1 for the cdsci-lake systemd scheduling convention -- see
+# monode/infrastructure's SCHEDULING.md for the full pattern this is an
+# instance of.
+[Unit]
+Description=Load Retraction Watch into lake.retractionwatch.retractions
+Documentation=file:///home/davsean/Documents/git/cdsci-lake/docs/design/dashboard_and_scheduling.md
+After=network-online.target
+Wants=network-online.target
+OnFailure=ntfy-notify@%N.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=/home/davsean/Documents/git/cdsci-lake
+EnvironmentFile=/home/davsean/Documents/git/cdsci-lake/.env
+# Prod writes go to the shared Postgres-catalog lake; .env deliberately
+# omits this var so a plain test run can never hit prod by accident (see
+# cdsci.lake.config) -- set it explicitly here instead.
+Environment=CU_OPENALEX_LAKE_BACKEND=postgres
+ExecStart=/usr/bin/env uv run python -m cdsci.lake.sources.retractionwatch run
+# RuntimeMaxSec= silently has no effect on Type=oneshot (systemd quirk --
+# verified with `systemd-analyze verify`, don't reintroduce it). For
+# oneshot, the run-length ceiling is TimeoutStartSec=, matching
+# bioc-sync.service's existing use of the same directive for the same
+# reason. Historical runs finish in ~2s (small CSV); this ceiling is
+# generous on purpose so a slow network day doesn't false-alarm, while
+# still turning a genuine hang into a Failed state instead of an
+# invisible stuck process.
+TimeoutStartSec=1800
+
+[Install]
+WantedBy=default.target

--- a/systemd/retractionwatch.timer
+++ b/systemd/retractionwatch.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Weekday-daily Retraction Watch load (source cadence: weekday-daily)
+
+[Timer]
+OnCalendar=Mon..Fri *-*-* 07:00:00
+RandomizedDelaySec=300
+# Catch up after downtime rather than silently skipping to the next weekday.
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Closes #45. No Python changes -- CI will pass trivially (nothing for ruff/pytest to touch), keeping this in the same merge-on-green flow as everything else rather than special-casing it. See commit message for the RuntimeMaxSec/TimeoutStartSec bug caught by systemd-analyze verify, and the live verification (both jobs run once before going live, real backlog landed, ntfy alert chain confirmed with a real delivered notification).