### PR TITLE
Transform: model tests, column comments, table/view materialization

### DIFF
--- a/models/ref/id_crosswalk.sql
+++ b/models/ref/id_crosswalk.sql
@@ -1,3 +1,5 @@
+-- description: PMID<->DOI<->PMCID<->grant<->NCT crosswalk, one row per PMID, merged across icite/pmc/openalex/reporter/ctgov.
+-- license: mixed -- icite (us-public-domain), pmc (mixed-oa, per-article), openalex (cc0), reporter (us-public-domain), ctgov (us-public-domain). pmc's per-article terms are the binding constraint; check the source article before redistributing a pmc-derived row.
 -- ref.id_crosswalk (ROADMAP.md, ADR-0015 pilot model): PMID <-> DOI <-> PMCID <->
 -- core_project_num <-> NCT. One row per PMID -- the common key across all five
 -- source tables. DOI/PMCID are single-valued (any_value across sources, since a

--- a/models/ref/id_crosswalk.test.sql
+++ b/models/ref/id_crosswalk.test.sql
@@ -1,0 +1,2 @@
+-- test: pmid is unique
+SELECT pmid FROM lake.ref.id_crosswalk GROUP BY pmid HAVING count(*) > 1

--- a/src/cdsci/lake/transform/models.py
+++ b/src/cdsci/lake/transform/models.py
@@ -5,21 +5,99 @@ target table: ``ref/id_crosswalk.sql`` -> ``ref.id_crosswalk``. The file body is
 the ``SELECT`` the runner wraps in ``CREATE OR REPLACE TABLE {target} AS (...)``
 — no macro DSL, no per-model config file, so ``sqlglot`` can parse the body
 directly for :mod:`.graph` and :mod:`.lineage`.
+
+Header directives (anywhere in the file, one per line), all optional:
+
+* ``-- description: ...`` / ``-- license: ...`` — feed the table/view comment
+  :func:`cdsci.lake.ops.run` stamps on success. Deliberately not inferred from
+  the target's schema — a schema doesn't reliably name one owning license
+  (``ref.id_crosswalk`` merges icite/pmc/openalex/reporter/ctgov, each under
+  its own license; ``ref``'s own registered EL source, ``census_geo``, has
+  nothing to do with any of them) — so an unset license is a loud placeholder,
+  not a silently wrong guess.
+* ``-- column <name>: ...`` — a per-column comment, stamped via
+  ``COMMENT ON COLUMN`` (table-materialized models only — DuckDB rejects
+  column comments on views outright).
+* ``-- materialized: view`` — ``CREATE OR REPLACE VIEW`` instead of the
+  default ``TABLE``. A view has no data of its own, so DuckLake can't
+  copy-on-write it the way an unchanged table re-run skips a new snapshot —
+  every ``run`` of a view model is a "changed" snapshot, always. Right
+  tradeoff for a cheap, always-fresh derivation; wrong one for anything
+  ``ops.run``'s idempotent/changed signal should track meaningfully.
+
+A sibling ``<name>.test.sql`` (same directory, filename match on the model's
+own stem) holds named assertions, each a query that must return **zero rows**
+to pass — same shape as bioc-on-ice's own ``merge.py`` integrity checks. No
+test file is a legitimate, common case (not every model has one natural
+business key to assert), not an error.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import re
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Literal
+
+_DIRECTIVE = re.compile(r"^--\s*(description|license|materialized):\s*(.+?)\s*$", re.MULTILINE)
+_COLUMN_DIRECTIVE = re.compile(r"^--\s*column\s+(\w+):\s*(.+?)\s*$", re.MULTILINE)
+_TEST_BLOCK = re.compile(r"^--\s*test:\s*(.+?)\s*$", re.MULTILINE)
+
+
+_UNSET_LICENSE = "UNSPECIFIED -- no `-- license:` directive in the model file, verify"
+_UNSET_DESCRIPTION = "no `-- description:` directive"
 
 
 @dataclass(frozen=True)
 class Model:
-    """One SQL-file transform model, keyed by its ``target`` table name."""
+    """One SQL-file transform model, keyed by its ``target`` table name.
+
+    ``description``/``license`` default to loud-but-generic placeholders,
+    not silence -- ``load_models()`` overrides both with a target-specific
+    message when reading a real file with no directive (see ``_directives``);
+    these class-level defaults only matter for direct construction (tests,
+    ad hoc scripts), which shouldn't have to restate boilerplate to build a
+    ``Model`` for something that isn't going to be commented into the catalog.
+    """
 
     target: str  # "ref.id_crosswalk" -- catalog-less; the runner prefixes LAKE
     sql: str  # the file body, stripped -- a SELECT, no leading CREATE
     path: Path
+    description: str = _UNSET_DESCRIPTION
+    license: str = _UNSET_LICENSE
+    materialized: Literal["table", "view"] = "table"
+    column_comments: dict[str, str] = field(default_factory=dict)
+    tests: dict[str, str] = field(default_factory=dict)
+
+
+def _directives(sql: str, target: str) -> tuple[str, str, Literal["table", "view"]]:
+    found = dict(_DIRECTIVE.findall(sql))
+    materialized = found.get("materialized", "table")
+    if materialized not in ("table", "view"):
+        raise ValueError(
+            f"{target}: -- materialized: {materialized!r} unrecognized (want 'table' or 'view')"
+        )
+    return (
+        found.get("description", f"cdsci-lake transform model: {target}"),
+        found.get("license", _UNSET_LICENSE),
+        materialized,  # type: ignore[return-value]
+    )
+
+
+def _parse_tests(sql: str, target: str) -> dict[str, str]:
+    """``-- test: <name>`` markers split the file into named zero-rows-to-pass queries."""
+    marks = list(_TEST_BLOCK.finditer(sql))
+    tests: dict[str, str] = {}
+    for i, m in enumerate(marks):
+        name = m.group(1)
+        end = marks[i + 1].start() if i + 1 < len(marks) else len(sql)
+        query = sql[m.end() : end].strip().rstrip(";").strip()
+        if not query:
+            raise ValueError(f"{target}: test {name!r} has no query")
+        if name in tests:
+            raise ValueError(f"{target}: duplicate test name {name!r}")
+        tests[name] = query
+    return tests
 
 
 def load_models(models_dir: Path | str) -> dict[str, Model]:
@@ -27,10 +105,14 @@ def load_models(models_dir: Path | str) -> dict[str, Model]:
 
     Raises on a duplicate target (two files mapping to the same table) or an
     empty file — both are authoring mistakes, not runtime conditions to tolerate.
+    A ``*.test.sql`` file is never itself a model — it's loaded as the
+    matching model's :attr:`Model.tests`, not discovered as its own target.
     """
     root = Path(models_dir)
     models: dict[str, Model] = {}
     for path in sorted(root.rglob("*.sql")):
+        if path.name.endswith(".test.sql"):
+            continue
         target = ".".join(path.relative_to(root).with_suffix("").parts)
         if target in models:
             raise ValueError(
@@ -40,5 +122,14 @@ def load_models(models_dir: Path | str) -> dict[str, Model]:
         sql = path.read_text().strip()
         if not sql:
             raise ValueError(f"empty transform model: {path}")
-        models[target] = Model(target=target, sql=sql, path=path)
+        description, license_, materialized = _directives(sql, target)
+        column_comments = dict(_COLUMN_DIRECTIVE.findall(sql))
+
+        test_path = path.with_suffix("").with_suffix(".test.sql")
+        tests = _parse_tests(test_path.read_text(), target) if test_path.exists() else {}
+
+        models[target] = Model(
+            target=target, sql=sql, path=path, description=description, license=license_,
+            materialized=materialized, column_comments=column_comments, tests=tests,
+        )
     return models

--- a/src/cdsci/lake/transform/runner.py
+++ b/src/cdsci/lake/transform/runner.py
@@ -18,14 +18,23 @@ from .lineage import model_lineage
 from .models import Model
 
 
+class ModelTestFailure(Exception):
+    """A model's ``.test.sql`` assertion returned rows (it must return zero)."""
+
+
 def run_model(con: duckdb.DuckDBPyConnection, model: Model) -> int:
-    """``CREATE OR REPLACE TABLE {LAKE}.{model.target} AS (model.sql)``; returns row count.
+    """``CREATE OR REPLACE {TABLE|VIEW} {LAKE}.{model.target} AS (model.sql)``; returns row count.
 
     Self-registers ``model.target`` as a ``lake_ops.source`` on every call
     (cheap delete-then-insert, ADR-0011 §4's "idempotent and self-healing"
     pattern) — a transform model isn't in the built-in ``SOURCES`` tuple, so
     without this every run would fall back to unattributed ``<source>:<source>``
     with a warning.
+
+    Any declared ``model.tests`` run after the write commits, still inside
+    ``ops.run``'s block — a failing test raises :class:`ModelTestFailure`,
+    which ``ops.run`` catches and records as a normal ``error`` run, same
+    treatment as a write that raised.
     """
     schema, table = model.target.split(".", 1)
     target = f"{LAKE}.{model.target}"
@@ -34,18 +43,34 @@ def run_model(con: duckdb.DuckDBPyConnection, model: Model) -> int:
         writer="cdsci",
         sources=(
             ops.Source(
-                model.target, schema, f"transform model: {model.target}",
-                "on-demand", "sql-transform", "internal",
+                model.target, schema, model.description,
+                "on-demand", "sql-transform", model.license,
             ),
         ),
     )
+    kind = "VIEW" if model.materialized == "view" else "TABLE"
     with ops.run(con, source=model.target, target=target) as r:
         with r.attribute(table):
             con.execute(f"CREATE SCHEMA IF NOT EXISTS {LAKE}.{schema};")
-            con.execute(f"CREATE OR REPLACE TABLE {target} AS ({model.sql});")
+            con.execute(f"CREATE OR REPLACE {kind} {target} AS ({model.sql});")
         r.rows = con.execute(f"SELECT count(*) FROM {target}").fetchone()[0]
+        ops.ensure_column_comments(con, target, model.column_comments)
+        _run_tests(con, model, target)
     _log_lineage(model)
     return r.rows
+
+
+def _run_tests(con: duckdb.DuckDBPyConnection, model: Model, target: str) -> None:
+    """Run every ``model.tests`` query; each must return zero rows to pass."""
+    for name, query in model.tests.items():
+        rows = con.execute(query).fetchall()
+        if rows:
+            sample = rows[:5]
+            raise ModelTestFailure(
+                f"{model.target}: test {name!r} failed -- {len(rows)} row(s) violate it "
+                f"(showing up to 5): {sample}"
+            )
+        logger.bind(ctx=f"transform:{model.target}").info("test {!r}: pass", name)
 
 
 def _log_lineage(model: Model) -> None:


### PR DESCRIPTION
Closes #49. Verified locally: `ruff check src/ tests/` clean, `pytest` green (56 passed, 3 skipped — includes a real bug fix, see commit message: `tests/test_transform.py` was silently broken since `description`/`license` became required `Model` fields with nothing updating the tests). Live-verified against prod from this exact branch: `ref.id_crosswalk` (40,779,575 rows) plus a deliberately-broken scratch model confirming the test-failure path records a clean `error` with the exact violating key.