### PR TITLE
Fix transform publish() TypeError: date is parquet-only, not universal

### DIFF
--- a/src/cdsci/lake/transform/targets.py
+++ b/src/cdsci/lake/transform/targets.py
@@ -50,15 +50,18 @@ class Target:
 
 
 def publish(
-    con: duckdb.DuckDBPyConnection, source_table: str, target: Target, *, date: str
+    con: duckdb.DuckDBPyConnection, source_table: str, target: Target, *, date: str | None = None
 ) -> None:
     """Publish ``source_table`` (a catalog-qualified lake table) to ``target``.
 
-    ``date`` is a caller-supplied stamp (the ``parquet`` dated-copy pattern) —
-    passed in rather than computed here, so this function stays pure with
-    respect to wall-clock time.
+    ``date`` is a caller-supplied stamp for the ``parquet`` dated-copy pattern
+    only — passed in rather than computed here, so this function stays pure
+    with respect to wall-clock time. Required for ``parquet``, unused by every
+    other target type.
     """
     if target.type == "parquet":
+        if date is None:
+            raise ValueError("date is required for the 'parquet' target type")
         _publish_parquet(con, source_table, target.config, date)
     elif target.type in ("duckdb", "lake_table"):
         _publish_duckdb(con, source_table, target.config)

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -177,3 +177,25 @@ def test_publish_duckdb_and_lake_table_noop(lake_settings: Settings, tmp_path: P
         publish(con, "lake.a.t1", Target("lake_table"), date="2026-08-07")
     finally:
         con.close()
+
+
+def test_publish_date_optional_for_non_parquet_targets(lake_settings: Settings, tmp_path: Path):
+    """date is parquet-only — the CLI's iceberg publish path never supplies one."""
+    con = lake_connect(lake_settings)
+    try:
+        con.execute("CREATE SCHEMA lake.a; CREATE TABLE lake.a.t1 AS SELECT 1 AS x")
+        mart_path = tmp_path / "mart.duckdb"
+        publish(con, "lake.a.t1", Target("duckdb", {"path": str(mart_path)}))
+        publish(con, "lake.a.t1", Target("lake_table"))
+    finally:
+        con.close()
+
+
+def test_publish_parquet_requires_date(lake_settings: Settings):
+    con = lake_connect(lake_settings)
+    try:
+        con.execute("CREATE SCHEMA lake.a; CREATE TABLE lake.a.t1 AS SELECT 1 AS x")
+        with pytest.raises(ValueError, match="date is required"):
+            publish(con, "lake.a.t1", Target("parquet", {"path": "/tmp/{date}/t1.parquet"}))
+    finally:
+        con.close()


### PR DESCRIPTION
## Summary
- `publish()` required `date` for every target type, but only the `parquet` dated-copy pattern uses it — the CLI's `iceberg` path never had one to supply, so every `transform publish` invocation raised `TypeError` before touching the network
- `date` is now optional, required only inside the `parquet` branch, with a clear `ValueError` if omitted there

Closes #53. Unblocks reverse-ETL on #31, #32, #35, #36, #37, #38, #39.

## Test plan
- [x] `test_publish_date_optional_for_non_parquet_targets` — duckdb/lake_table publish with no `date` kwarg
- [x] `test_publish_parquet_requires_date` — parquet publish without `date` raises a clear error
- [x] `uv run pytest tests/test_transform.py -q` — 13 passed
- [x] `uv run ruff check src/ tests/` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FposEN8ErZTLzsjTfSdZjj