### PR TITLE
Collapse the 14 ingestor CLIs into the Source declaration

### DIFF
--- a/docs/design/ontology.md
+++ b/docs/design/ontology.md
@@ -81,9 +81,9 @@ and `terms.obsolete = false` (not deprecated; offer `replaced_by` if it is).
 python -m cdsci.lake.sources.ontology list
 
 # load specific ontologies
-python -m cdsci.lake.sources.ontology run -o uberon -o ncit -o hancestro
+python -m cdsci.lake.sources.ontology run --ontologies uberon --ontologies ncit --ontologies hancestro
 
-# load ALL available ontologies (omit --ontology)
+# load ALL available ontologies (omit --ontologies)
 python -m cdsci.lake.sources.ontology run
 
 # show the projected tables + keys

--- a/src/cdsci/lake/ops.py
+++ b/src/cdsci/lake/ops.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import json
 import socket
 import uuid
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
@@ -74,6 +74,17 @@ class Source:
     # multi-producer, so each row records which writer registered it (`cdsci`,
     # `omicidx`), making "show me all of <producer>'s sources/loads" one query.
     writer: str = "cdsci"
+    # The source's own entrypoint (issue #52): `ingest(**kwargs) -> dict`, self-
+    # connecting and self-bracketed in `run()`. Left unset here -- `SOURCES`
+    # below is imported by the base `cdsci.lake` package (the read-client
+    # surface, no ingest deps installed) and importing all 14 `sources/*/ingest`
+    # modules here would both violate that packaging boundary and cycle back
+    # into this module (each imports `from ... import ops`). Instead
+    # `sources/_cli.py` looks a source up by name and attaches its already
+    # locally-imported `ingest` via `dataclasses.replace` at CLI-build time --
+    # so a name absent from `SOURCES` still can't get a CLI, which is the
+    # structural fix this field exists for.
+    ingest: Callable[..., dict] | None = None
 
 
 SOURCES: tuple[Source, ...] = (
@@ -105,6 +116,8 @@ SOURCES: tuple[Source, ...] = (
            "annual", "zenodo", "cc-by-nc-4.0"),
     Source("bioregistry", "ref", "Bioregistry: canonical identifier prefixes, patterns, synonyms",
            "weekly", "github-tsv", "cc0"),
+    Source("ontology", "ontology", "OBO semantic-sql builds: terms/synonyms/xrefs/edges",
+           "on-release", "semsql-s3", "mixed"),
 )
 
 

--- a/src/cdsci/lake/sources/_cli.py
+++ b/src/cdsci/lake/sources/_cli.py
@@ -1,0 +1,104 @@
+"""Shared typer CLI driver for a registered :class:`~cdsci.lake.ops.Source` (issue #52).
+
+Every source's real work already lives in one ``ingest(**kwargs) -> dict``
+function that self-connects, self-brackets in :func:`cdsci.lake.ops.run`, and
+returns a summary dict (a superset of ``ops.Run.summary()``). What every
+``sources/*/__main__.py`` restated by hand was just the shell around that: a
+typer app, a ``--log-level`` callback wired to :func:`cdsci.lake.log.configure`,
+and a ``run`` command mapping CLI flags 1:1 onto ``ingest()``'s own keyword
+parameters, then echoing the summary.
+
+:func:`build_app` generates that shell from ``ingest``'s real signature via
+``inspect``, so a source's CLI options fall out of its function signature for
+free -- no per-source restating. It also requires ``name`` to be a member of
+:data:`ops.SOURCES`: a source absent from the registry (the drift ``ontology``
+fell into) structurally cannot get a CLI here.
+
+Sources with more than one entrypoint (``mesh``) or a ``run`` that is genuinely
+more than a kwargs pass-through (``scp``'s ``domain=path`` parsing, ``openalex``'s
+shared-connection multi-entity loop) keep hand-written commands --
+:func:`base_app` gives them just the ``--log-level`` shell to build on, so even
+the bespoke ones don't restate *that*.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import inspect
+import typing
+from collections.abc import Callable
+from typing import Any
+
+import typer
+
+from .. import ops
+from ..log import configure
+
+# Driver-injected concerns, never a CLI option: `settings` is the driver's own
+# Settings() default, and no ingest() should take a raw DuckDB connection from
+# a CLI user -- if one ever does, it stays hand-written (see openalex).
+_NOT_CLI_PARAMS = {"settings", "con"}
+
+
+def base_app(help: str) -> typer.Typer:  # noqa: A002 - matches typer.Typer's own kwarg name
+    """A typer app with the one shared piece every source's CLI needs: ``--log-level``."""
+    app = typer.Typer(help=help, add_completion=False)
+
+    @app.callback()
+    def _main(log_level: str = typer.Option("INFO", "--log-level", help="loguru level.")) -> None:
+        configure(log_level)
+
+    return app
+
+
+def _run_signature(ingest: Callable[..., dict]) -> inspect.Signature:
+    """``ingest``'s own keyword parameters -- typer builds CLI options from these.
+
+    Every ``ingest()`` module has ``from __future__ import annotations``, so
+    ``inspect.signature`` alone hands back unevaluated strings (``"str | None"``)
+    that typer/click can't turn into a parser. ``get_type_hints`` resolves them
+    to real type objects first.
+    """
+    hints = typing.get_type_hints(ingest)
+    params = [
+        p.replace(annotation=hints.get(pname, p.annotation))
+        for pname, p in inspect.signature(ingest).parameters.items()
+        if pname not in _NOT_CLI_PARAMS
+    ]
+    return inspect.Signature(params)
+
+
+def _echo_summary(summary: dict[str, Any]) -> None:
+    """One generic report line -- every ingest() returns a superset of ``ops.Run.summary()``."""
+    target = summary.get("table") or summary.get("schema") or "?"
+    rows = summary.get("rows") or 0
+    delta = "changed" if summary.get("changed") else "no change (idempotent)"
+    typer.echo(f"{target} <- {rows:,} rows (status={summary.get('status')}) — {delta}")
+
+
+def build_app(name: str, ingest: Callable[..., dict], *, help: str) -> typer.Typer:  # noqa: A002
+    """A ready-to-run typer app for a registered source: ``--log-level`` + a generated ``run``.
+
+    ``name`` must be one of :data:`ops.SOURCES`'s names -- an unregistered source
+    has no ledger row to attribute a run to, so wiring a CLI for one is refused
+    outright rather than silently running unattributed (issue #52). The matching
+    :class:`ops.Source` is stamped with ``ingest`` (via ``dataclasses.replace`` --
+    ``SOURCES`` itself stays free of ingest-extra imports, see ``ops.Source.ingest``),
+    so the source that ends up driving the CLI is the registered one, not just a
+    same-named function the caller happened to pass in.
+    """
+    matches = [s for s in ops.SOURCES if s.name == name]
+    if not matches:
+        raise ValueError(
+            f"{name!r} is not registered in ops.SOURCES -- register it there before "
+            "wiring a CLI; a source not in the registry cannot be run"
+        )
+    source = dataclasses.replace(matches[0], ingest=ingest)
+    app = base_app(help)
+
+    def run(**kwargs: Any) -> None:
+        _echo_summary(source.ingest(**kwargs))
+
+    run.__signature__ = _run_signature(source.ingest)  # type: ignore[attr-defined]
+    app.command("run")(run)
+    return app

--- a/src/cdsci/lake/sources/bioregistry/__main__.py
+++ b/src/cdsci/lake/sources/bioregistry/__main__.py
@@ -2,36 +2,12 @@
 
 from __future__ import annotations
 
-import typer
-
-from ...log import configure
+from .._cli import build_app
 from .ingest import ingest
 
-app = typer.Typer(
-    help="Ingest the Bioregistry consensus export into lake.ref.bioregistry.",
-    add_completion=False,
+app = build_app(
+    "bioregistry", ingest, help="Ingest the Bioregistry consensus export into lake.ref.bioregistry."
 )
-
-
-@app.callback()
-def main(log_level: str = typer.Option("INFO", "--log-level", help="loguru level.")) -> None:
-    """Bioregistry ingestor (keeps the ``run`` subcommand explicit)."""
-    configure(log_level)
-
-
-@app.command("run")
-def run(
-    file: str | None = typer.Option(
-        None, "--file", help="Local TSV to load instead of downloading."
-    ),
-    schema: str = typer.Option("ref", "--schema", help="Target lake schema."),
-    limit: int | None = typer.Option(None, "--limit", help="Cap rows (smoke test)."),
-) -> None:
-    """Download (unless --file) and MERGE-upsert the current registry export."""
-    summary = ingest(file=file, schema=schema, limit=limit)
-    delta = "changed" if summary["changed"] else "no change (idempotent)"
-    typer.echo(f"{summary['table']} <- {summary['rows']:,} rows — {delta}")
-
 
 if __name__ == "__main__":
     app()

--- a/src/cdsci/lake/sources/bugsigdb/__main__.py
+++ b/src/cdsci/lake/sources/bugsigdb/__main__.py
@@ -2,42 +2,12 @@
 
 from __future__ import annotations
 
-import typer
-
-from ...log import configure
+from .._cli import build_app
 from .ingest import ingest
 
-app = typer.Typer(
-    help="Ingest a BugSigDB release tag into lake.bugsigdb.signatures.",
-    add_completion=False,
+app = build_app(
+    "bugsigdb", ingest, help="Ingest a BugSigDB release tag into lake.bugsigdb.signatures."
 )
-
-
-@app.callback()
-def main(log_level: str = typer.Option("INFO", "--log-level", help="loguru level.")) -> None:
-    """BugSigDB ingestor (keeps the ``run`` subcommand explicit)."""
-    configure(log_level)
-
-
-@app.command("run")
-def run(
-    file: str | None = typer.Option(
-        None, "--file", help="Local CSV to load instead of downloading."
-    ),
-    version: str | None = typer.Option(
-        None, "--version", help="BugSigDB release tag (default: Settings.bugsigdb_version)."
-    ),
-    schema: str = typer.Option("bugsigdb", "--schema", help="Target lake schema."),
-    limit: int | None = typer.Option(None, "--limit", help="Cap rows (smoke test)."),
-) -> None:
-    """Download (unless --file) and MERGE-upsert one BugSigDB release tag."""
-    summary = ingest(file=file, version=version, schema=schema, limit=limit)
-    delta = "changed" if summary["changed"] else "no change (idempotent)"
-    typer.echo(
-        f"{summary['table']} <- {summary['rows']:,} rows "
-        f"(release {summary['version']}) — {delta}"
-    )
-
 
 if __name__ == "__main__":
     app()

--- a/src/cdsci/lake/sources/census_geo/__main__.py
+++ b/src/cdsci/lake/sources/census_geo/__main__.py
@@ -4,18 +4,13 @@ from __future__ import annotations
 
 import typer
 
-from ...log import configure
+from .._cli import build_app
 from .ingest import LAYERS, ingest
 
-app = typer.Typer(
+app = build_app(
+    "census_geo", ingest,
     help="Load US Census cartographic boundaries into ref.geo_state / ref.geo_county.",
-    add_completion=False,
 )
-
-
-@app.callback()
-def _main(log_level: str = typer.Option("INFO", "--log-level", help="loguru level.")) -> None:
-    configure(log_level)
 
 
 @app.command("layers")
@@ -23,19 +18,6 @@ def layers() -> None:
     """List the boundary layers."""
     for name, spec in LAYERS.items():
         typer.echo(f"  {name:<12} cb_*_{spec.layer}_500k  key={','.join(spec.key)}")
-
-
-@app.command("run")
-def run(
-    layer: list[str] = typer.Option(
-        None, "--layer", "-l", help="Layer(s) to load; omit for all (state + county)."
-    ),
-    schema: str = typer.Option("ref", "--schema", help="Target lake schema."),
-    year: int | None = typer.Option(None, "--year", help="Cartographic boundary vintage."),
-) -> None:
-    """Download + MERGE-upsert Census boundaries into the ref schema."""
-    summary = ingest(layers=layer or None, schema=schema, year=year)
-    typer.echo(f"ref geo loaded (cb {summary['year']}): {summary['counts']}")
 
 
 if __name__ == "__main__":

--- a/src/cdsci/lake/sources/ctgov/__main__.py
+++ b/src/cdsci/lake/sources/ctgov/__main__.py
@@ -6,18 +6,13 @@ import typer
 
 from ...config import get_settings
 from ...download import get_json
-from ...log import configure
+from .._cli import build_app
 from .ingest import ingest
 
-app = typer.Typer(
+app = build_app(
+    "ctgov", ingest,
     help="Ingest ClinicalTrials.gov studies (full JSON) into lake.ctgov.{studies,references}.",
-    add_completion=False,
 )
-
-
-@app.callback()
-def _main(log_level: str = typer.Option("INFO", "--log-level", help="loguru level.")) -> None:
-    configure(log_level)
 
 
 @app.command("count")
@@ -26,28 +21,6 @@ def count() -> None:
     s = get_settings()
     data = get_json(s.ctgov_api, params={"pageSize": 1, "countTotal": "true", "format": "json"})
     typer.echo(f"ClinicalTrials.gov studies available: {data.get('totalCount'):,}")
-
-
-@app.command("run")
-def run(
-    file: str | None = typer.Option(
-        None, "--file", help="Local NDJSON extract or .parquet to load instead of downloading."
-    ),
-    schema: str = typer.Option(
-        "ctgov", "--schema", help="Target lake schema (e.g. _dev to stage before promoting)."
-    ),
-    max_pages: int | None = typer.Option(
-        None, "--max-pages", help="Cap API pages (~1000 studies each) for a partial run."
-    ),
-    limit: int | None = typer.Option(None, "--limit", help="Cap rows (smoke test)."),
-) -> None:
-    """Download → materialize bronze Parquet → upsert ctgov.studies + ctgov.references."""
-    s = ingest(file=file, schema=schema, max_pages=max_pages, limit=limit)
-    delta = "changed" if s["changed"] else "no change (idempotent)"
-    typer.echo(
-        f"{s['studies_table']} <- {s['studies']:,} studies; "
-        f"{s['references_table']} <- {s['references']:,} refs — {delta}"
-    )
 
 
 if __name__ == "__main__":

--- a/src/cdsci/lake/sources/europepmc/__main__.py
+++ b/src/cdsci/lake/sources/europepmc/__main__.py
@@ -4,18 +4,13 @@ from __future__ import annotations
 
 import typer
 
-from ...log import configure
+from .._cli import build_app
 from .ingest import ingest, list_databases
 
-app = typer.Typer(
+app = build_app(
+    "europepmc", ingest,
     help="Ingest Europe PMC text-mined annotations into lake.europepmc.annotations.",
-    add_completion=False,
 )
-
-
-@app.callback()
-def _main(log_level: str = typer.Option("INFO", "--log-level", help="loguru level.")) -> None:
-    configure(log_level)
 
 
 @app.command("databases")
@@ -25,27 +20,6 @@ def databases() -> None:
     for name in names:
         typer.echo(f"  {name}")
     typer.echo(f"{len(names)} databases")
-
-
-@app.command("run")
-def run(
-    database: str | None = typer.Option(
-        None, "--database", "-d", help="Single database (file stem); omit for all."
-    ),
-    file: str | None = typer.Option(None, "--file", help="Local CSV to load instead."),
-    version: str | None = typer.Option(
-        None, "--version", help="Snapshot label (default: today's date)."
-    ),
-    schema: str = typer.Option("europepmc", "--schema", help="Target lake schema."),
-    limit: int | None = typer.Option(None, "--limit", help="Cap rows per file (smoke test)."),
-) -> None:
-    """Download (unless --file) and MERGE-upsert annotations into one tidy table."""
-    summary = ingest(database=database, file=file, version=version, schema=schema, limit=limit)
-    delta = "changed" if summary["changed"] else "no change (idempotent)"
-    typer.echo(
-        f"{summary['table']} <- {summary['rows']:,} rows across "
-        f"{summary['databases']} database(s) (snapshot {summary['version']}) — {delta}"
-    )
 
 
 if __name__ == "__main__":

--- a/src/cdsci/lake/sources/icite/__main__.py
+++ b/src/cdsci/lake/sources/icite/__main__.py
@@ -4,18 +4,12 @@ from __future__ import annotations
 
 import typer
 
-from ...log import configure
+from .._cli import build_app
 from .ingest import ingest, resolve_latest
 
-app = typer.Typer(
-    help="Ingest the monthly iCite bulk snapshot into lake.icite.metadata.",
-    add_completion=False,
+app = build_app(
+    "icite", ingest, help="Ingest the monthly iCite bulk snapshot into lake.icite.metadata."
 )
-
-
-@app.callback()
-def _main(log_level: str = typer.Option("INFO", "--log-level", help="loguru level.")) -> None:
-    configure(log_level)
 
 
 @app.command("latest")
@@ -25,26 +19,6 @@ def latest() -> None:
     typer.echo(f"latest snapshot: {info['version']}")
     for f in info["files"]:
         typer.echo(f"  {f.get('name')}  {round(f.get('size', 0) / 1e6, 1)} MB")
-
-
-@app.command("run")
-def run(
-    file: str | None = typer.Option(
-        None, "--file", help="Local CSV/TSV (glob ok) to load instead of downloading."
-    ),
-    version: str | None = typer.Option(None, "--version", help="Label this snapshot version."),
-    schema: str = typer.Option(
-        "icite", "--schema", help="Target lake schema (e.g. _dev to stage before promoting)."
-    ),
-    limit: int | None = typer.Option(None, "--limit", help="Cap rows (smoke test)."),
-) -> None:
-    """Download (unless --file) and MERGE-upsert the snapshot into lake.icite.metadata."""
-    summary = ingest(file=file, version=version, schema=schema, limit=limit)
-    delta = "changed" if summary["changed"] else "no change (idempotent)"
-    typer.echo(
-        f"{summary['table']} <- {summary['rows']:,} rows "
-        f"(snapshot {summary['version']}) — {delta}"
-    )
 
 
 if __name__ == "__main__":

--- a/src/cdsci/lake/sources/mesh/__main__.py
+++ b/src/cdsci/lake/sources/mesh/__main__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import typer
 
-from ...log import configure
+from .._cli import base_app
 from .ingest import (
     ingest,
     ingest_chemicals,
@@ -13,15 +13,7 @@ from .ingest import (
     ingest_supplemental,
 )
 
-app = typer.Typer(
-    help="Ingest NLM MeSH descriptors + tree hierarchy + qualifiers into lake.mesh.*.",
-    add_completion=False,
-)
-
-
-@app.callback()
-def _main(log_level: str = typer.Option("INFO", "--log-level", help="loguru level.")) -> None:
-    configure(log_level)
+app = base_app(help="Ingest NLM MeSH descriptors + tree hierarchy + qualifiers into lake.mesh.*.")
 
 
 @app.command("run")

--- a/src/cdsci/lake/sources/ontology/__main__.py
+++ b/src/cdsci/lake/sources/ontology/__main__.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import typer
 
+from .._cli import build_app
 from .ingest import RELATIONS, available_ontologies, ingest
 
-app = typer.Typer(
+app = build_app(
+    "ontology", ingest,
     help="Load semantic-sql OBO ontologies into the ontology schema (terms/synonyms/xrefs/edges).",
-    add_completion=False,
 )
 
 
@@ -25,20 +26,6 @@ def list_ontologies() -> None:
     onts = available_ontologies()
     typer.echo("\n".join(onts))
     typer.echo(f"\n{len(onts)} ontologies available.")
-
-
-@app.command("run")
-def run(
-    ontology: list[str] = typer.Option(
-        None, "--ontology", "-o", help="Ontology stem(s) to load; omit for ALL in the bucket."
-    ),
-    schema: str = typer.Option("ontology", "--schema", help="Target lake schema."),
-) -> None:
-    """Download + MERGE-upsert ontologies into the ontology schema."""
-    summary = ingest(ontologies=ontology or None, schema=schema)
-    typer.echo(f"ontology loaded: {summary['loaded']} ontologies into {summary['schema']}.*")
-    if summary["errors"]:
-        typer.echo(f"  {len(summary['errors'])} failed: {', '.join(summary['errors'])}")
 
 
 if __name__ == "__main__":

--- a/src/cdsci/lake/sources/ontology/ingest.py
+++ b/src/cdsci/lake/sources/ontology/ingest.py
@@ -34,12 +34,13 @@ import gzip
 import shutil
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import date, datetime
 from pathlib import Path
 
 import duckdb
 import httpx
 
+from ... import ops
 from ...config import Settings, get_settings
 from ...connect import LAKE, lake_connect, raw_dir, upsert
 from ...download import download
@@ -246,6 +247,11 @@ def curate(
     return counts
 
 
+def _today_version() -> str:
+    """Run-level label -- each table's own `snapshot_version` is the per-ontology release."""
+    return date.today().isoformat()
+
+
 def ingest(
     *,
     ontologies: list[str] | None = None,
@@ -255,20 +261,29 @@ def ingest(
     """Download + curate ontologies (default: every one in the bucket).
 
     One DB at a time so memory stays flat; a failure on a single ontology is
-    recorded and skipped rather than aborting the whole batch.
+    recorded and skipped rather than aborting the whole batch. The whole batch is
+    one ``ops.run`` (ADR-0006), like every other source -- previously this ran
+    outside the ledger entirely (issue #52), leaving no run row and no attributed
+    snapshot.
     """
     s = settings or get_settings()
     onts = ontologies or available_ontologies(s)
+    target = f"{LAKE}.{schema}"
     con = lake_connect(s)
     counts: dict[str, dict[str, int]] = {}
     errors: dict[str, str] = {}
     try:
-        for onto in onts:
-            try:
-                db, release = fetch_db(onto, s)
-                counts[onto] = curate(con, onto, db, release, schema=schema)
-            except (httpx.HTTPError, duckdb.Error, OSError) as exc:
-                errors[onto] = f"{type(exc).__name__}: {exc}"
+        with ops.run(con, source="ontology", target=target, version=_today_version()) as r:
+            for onto in onts:
+                try:
+                    db, release = fetch_db(onto, s)
+                    counts[onto] = curate(con, onto, db, release, schema=schema)
+                except (httpx.HTTPError, duckdb.Error, OSError) as exc:
+                    errors[onto] = f"{type(exc).__name__}: {exc}"
+            r.rows = sum(sum(c.values()) for c in counts.values())
     finally:
         con.close()
-    return {"schema": schema, "loaded": len(counts), "counts": counts, "errors": errors}
+    return {
+        **r.summary(), "schema": schema, "loaded": len(counts),
+        "counts": counts, "errors": errors,
+    }

--- a/src/cdsci/lake/sources/openalex/__main__.py
+++ b/src/cdsci/lake/sources/openalex/__main__.py
@@ -15,18 +15,10 @@ import typer
 from ... import ops
 from ...config import get_settings
 from ...connect import LAKE, lake_connect
-from ...log import configure
+from .._cli import base_app
 from .ingest import ENTITIES, ingest_entity, ingest_works, part_urls
 
-app = typer.Typer(
-    help="Load the OpenAlex snapshot (works + reference entities) into the lake.",
-    add_completion=False,
-)
-
-
-@app.callback()
-def _main(log_level: str = typer.Option("INFO", "--log-level", help="loguru level.")) -> None:
-    configure(log_level)
+app = base_app(help="Load the OpenAlex snapshot (works + reference entities) into the lake.")
 
 
 @app.command("parts")

--- a/src/cdsci/lake/sources/pmc/__main__.py
+++ b/src/cdsci/lake/sources/pmc/__main__.py
@@ -4,18 +4,12 @@ from __future__ import annotations
 
 import typer
 
-from ...log import configure
+from .._cli import build_app
 from .ingest import ingest, list_ranges
 
-app = typer.Typer(
-    help="Ingest BioC-PMC full text into lake.pmc.documents + lake.pmc.passages.",
-    add_completion=False,
+app = build_app(
+    "pmc", ingest, help="Ingest BioC-PMC full text into lake.pmc.documents + lake.pmc.passages."
 )
-
-
-@app.callback()
-def _main(log_level: str = typer.Option("INFO", "--log-level", help="loguru level.")) -> None:
-    configure(log_level)
 
 
 @app.command("ranges")
@@ -25,42 +19,6 @@ def ranges() -> None:
     for f in fs:
         typer.echo(f"  {f}")
     typer.echo(f"  ({len(fs)} ranges)")
-
-
-@app.command("run")
-def run(
-    range_: list[str] = typer.Option(
-        None, "--range", "-r", help="Tarball filename(s) to load; omit for ALL ranges."
-    ),
-    file: str | None = typer.Option(
-        None, "--file", help="Local NDJSON or .parquet to load instead of downloading."
-    ),
-    schema: str = typer.Option("pmc", "--schema", help="Target lake schema (e.g. _dev to stage)."),
-    snapshot: str = typer.Option(
-        "bulk", "--snapshot", help="snapshot_version label stamped on rows (e.g. 2026-06)."
-    ),
-    mode: str = typer.Option(
-        "merge", "--mode", help="'append' for the initial bulk; 'merge' for incrementals."
-    ),
-    limit: int | None = typer.Option(None, "--limit", help="Cap rows (smoke test)."),
-    keep_raw: bool = typer.Option(
-        False, "--keep-raw", help="Keep the local tarball + NDJSON per range (default: delete)."
-    ),
-    passage_batches: int = typer.Option(
-        1, "--passage-batches",
-        help="Split the passages explosion into N pmcid shards (append mode) to cap spill.",
-    ),
-) -> None:
-    """Download (unless --file) BioC-PMC into pmc.documents + pmc.passages, per range."""
-    s = ingest(
-        ranges=range_ or None, file=file, schema=schema,
-        snapshot=snapshot, mode=mode, limit=limit, keep_raw=keep_raw,
-        passage_batches=passage_batches,
-    )
-    typer.echo(
-        f"{s['schema']} <- documents={s['documents']:,} passages={s['passages']:,}; "
-        f"ranges: {s['ranges']}"
-    )
 
 
 if __name__ == "__main__":

--- a/src/cdsci/lake/sources/reliance/__main__.py
+++ b/src/cdsci/lake/sources/reliance/__main__.py
@@ -5,42 +5,14 @@ CC BY-NC 4.0 — internal non-commercial use only; do not redistribute.
 
 from __future__ import annotations
 
-import typer
+from .._cli import build_app
+from .ingest import ingest
 
-from ...log import configure
-from .ingest import DATASETS, ingest
-
-app = typer.Typer(
+app = build_app(
+    "reliance", ingest,
     help="Ingest Reliance on Science (patent↔paper links) into lake.reliance.* "
     "[CC BY-NC 4.0 — internal, non-commercial; do not redistribute].",
-    add_completion=False,
 )
-
-
-@app.callback()
-def main(log_level: str = typer.Option("INFO", "--log-level", help="loguru level.")) -> None:
-    """Reliance on Science ingestor (keeps the ``run`` subcommand explicit)."""
-    configure(log_level)
-
-
-@app.command("run")
-def run(
-    dataset: str | None = typer.Option(
-        None, "--dataset", "-d", help=f"One of {list(DATASETS)}; omit for both."
-    ),
-    file: str | None = typer.Option(None, "--file", help="Local CSV for --dataset."),
-    version: str | None = typer.Option(None, "--version", help="Snapshot label."),
-    schema: str = typer.Option("reliance", "--schema", help="Target lake schema."),
-    limit: int | None = typer.Option(None, "--limit", help="Cap rows per file (smoke test)."),
-) -> None:
-    """Download + MERGE-upsert Reliance on Science into lake.reliance.*."""
-    summary = ingest(dataset=dataset, file=file, version=version, schema=schema, limit=limit)
-    delta = "changed" if summary["changed"] else "no change (idempotent)"
-    typer.echo(
-        f"lake.{schema}.* <- {summary['rows']:,} rows "
-        f"(snapshot {summary['version']}) — {delta}: {summary['counts']}"
-    )
-
 
 if __name__ == "__main__":
     app()

--- a/src/cdsci/lake/sources/reporter/__main__.py
+++ b/src/cdsci/lake/sources/reporter/__main__.py
@@ -4,18 +4,12 @@ from __future__ import annotations
 
 import typer
 
-from ...log import configure
+from .._cli import base_app
 from .ingest import GROUPS, available_years, ingest
 
-app = typer.Typer(
-    help="Ingest NIH RePORTER ExPORTER groups (projects/abstracts/publications/publink).",
-    add_completion=False,
+app = base_app(
+    help="Ingest NIH RePORTER ExPORTER groups (projects/abstracts/publications/publink)."
 )
-
-
-@app.callback()
-def _main(log_level: str = typer.Option("INFO", "--log-level", help="loguru level.")) -> None:
-    configure(log_level)
 
 
 @app.command("groups")
@@ -45,7 +39,13 @@ def run(
     ),
     limit: int | None = typer.Option(None, "--limit", help="Cap rows (smoke test)."),
 ) -> None:
-    """Download (unless --file) and MERGE-upsert an ExPORTER group into the lake."""
+    """Download (unless --file) and MERGE-upsert an ExPORTER group into the lake.
+
+    Hand-written (not generated): ``ingest()``'s ``files`` param is
+    ``list[str] | str | None`` for programmatic callers, a union typer/click
+    can't turn into one CLI option -- the CLI itself only ever needs the
+    repeatable-list shape.
+    """
     summary = ingest(
         group=group, years=year or None, files=file or None, schema=schema, limit=limit
     )

--- a/src/cdsci/lake/sources/retractionwatch/__main__.py
+++ b/src/cdsci/lake/sources/retractionwatch/__main__.py
@@ -2,42 +2,13 @@
 
 from __future__ import annotations
 
-import typer
-
-from ...log import configure
+from .._cli import build_app
 from .ingest import ingest
 
-app = typer.Typer(
+app = build_app(
+    "retractionwatch", ingest,
     help="Ingest the Retraction Watch CSV into lake.retractionwatch.retractions.",
-    add_completion=False,
 )
-
-
-@app.callback()
-def main(log_level: str = typer.Option("INFO", "--log-level", help="loguru level.")) -> None:
-    """Retraction Watch ingestor (keeps the ``run`` subcommand explicit)."""
-    configure(log_level)
-
-
-@app.command("run")
-def run(
-    file: str | None = typer.Option(
-        None, "--file", help="Local CSV to load instead of downloading."
-    ),
-    version: str | None = typer.Option(
-        None, "--version", help="Snapshot label (default: today's pull date)."
-    ),
-    schema: str = typer.Option("retractionwatch", "--schema", help="Target lake schema."),
-    limit: int | None = typer.Option(None, "--limit", help="Cap rows (smoke test)."),
-) -> None:
-    """Download (unless --file) and MERGE-upsert the Retraction Watch database."""
-    summary = ingest(file=file, version=version, schema=schema, limit=limit)
-    delta = "changed" if summary["changed"] else "no change (idempotent)"
-    typer.echo(
-        f"{summary['table']} <- {summary['rows']:,} rows "
-        f"(snapshot {summary['version']}) — {delta}"
-    )
-
 
 if __name__ == "__main__":
     app()

--- a/src/cdsci/lake/sources/scp/__main__.py
+++ b/src/cdsci/lake/sources/scp/__main__.py
@@ -4,18 +4,13 @@ from __future__ import annotations
 
 import typer
 
-from ...log import configure
+from .._cli import base_app
 from .ingest import DOMAINS, ingest, resolve_latest
 
-app = typer.Typer(
-    help="Ingest State Cancer Profiles (GitHub releases) into lake.scp.{incidence,mortality,risk,demographics}.",
-    add_completion=False,
+app = base_app(
+    help="Ingest State Cancer Profiles (GitHub releases) into "
+    "lake.scp.{incidence,mortality,risk,demographics}.",
 )
-
-
-@app.callback()
-def _main(log_level: str = typer.Option("INFO", "--log-level", help="loguru level.")) -> None:
-    configure(log_level)
 
 
 @app.command("latest")

--- a/tests/test_ontology.py
+++ b/tests/test_ontology.py
@@ -8,13 +8,21 @@ that replaces a materialized ``entailed_edge``. No network.
 
 from __future__ import annotations
 
+import importlib
 import sqlite3
 from pathlib import Path
 
 import pytest
 
-from cdsci.lake import Settings, lake_connect, snapshots
+from cdsci.lake import Settings, lake_connect, ops, snapshots
+from cdsci.lake.sources import ontology
 from cdsci.lake.sources.ontology import curate
+
+# `ontology/__init__.py` re-exports the `ingest` *function* under the same name
+# as the `ingest` *module* it lives in, shadowing the module on attribute access
+# -- `importlib.import_module` (a sys.modules lookup) sidesteps that, so tests
+# can monkeypatch the module-level helpers `ingest()` actually calls.
+ontology_ingest_module = importlib.import_module("cdsci.lake.sources.ontology.ingest")
 
 # (subject, predicate, object, value) — literals in value, IRI objects in object,
 # mirroring the real semsql encoding verified against hancestro.db.
@@ -125,5 +133,45 @@ def test_ontology_curate_idempotent(semsql_db: Path, lake_settings: Settings):
         first = curate(con, "xo", semsql_db, "2026-06-26")
         again = curate(con, "xo", semsql_db, "2026-06-26")
         assert first == again
+    finally:
+        con.close()
+
+
+def test_ontology_is_registered_in_sources():
+    """The issue #52 fix: ontology must be a member of ops.SOURCES, or it structurally
+    can't get a CLI (cdsci.lake.sources._cli.build_app) or an attributed ledger row."""
+    assert "ontology" in {s.name for s in ops.SOURCES}
+
+
+def test_ontology_ingest_wraps_ops_run(
+    semsql_db: Path, lake_settings: Settings, monkeypatch: pytest.MonkeyPatch
+):
+    """``ingest()`` used to run entirely outside the ledger (issue #52) -- no run row,
+    no attributed snapshot. It must now behave like every other source: one
+    ``ops.run`` bracket around the batch, landing one ledger row."""
+    monkeypatch.setattr(
+        ontology_ingest_module, "available_ontologies", lambda s=None: ["xo"]
+    )
+    monkeypatch.setattr(
+        ontology_ingest_module, "fetch_db", lambda onto, s=None: (semsql_db, "2026-06-26")
+    )
+
+    summary = ontology.ingest(schema="ontology", settings=lake_settings)
+
+    assert summary["loaded"] == 1
+    assert summary["errors"] == {}
+    assert summary["status"] in ("success", "idempotent")
+    assert summary["rows"] == 4 + 2 + 2 + 2  # terms + synonyms + xrefs + edges
+
+    con = lake_connect(lake_settings)
+    try:
+        last = ops.last_run(con, "ontology")
+        assert last is not None
+        assert last["status"] == summary["status"]
+        assert last["source"] == "ontology"
+        # self-registered as a built-in cdsci source (ops._self_register).
+        assert con.execute(
+            "SELECT writer FROM ops.lake_ops.source WHERE name='ontology'"
+        ).fetchone()[0] == "cdsci"
     finally:
         con.close()

--- a/tests/test_sources_cli.py
+++ b/tests/test_sources_cli.py
@@ -1,0 +1,90 @@
+"""Offline tests for the shared source CLI driver (``cdsci.lake.sources._cli``, issue #52).
+
+Exercises the two claims the issue's fix rests on: (1) the generated ``run``
+command is a thin shell over a source's own ``ingest()`` -- it doesn't
+re-implement the ``ops.run`` bracket, it just calls through, so any ledger row
+comes from ``ingest()`` itself, same as every hand-written CLI before it; and
+(2) a name absent from ``ops.SOURCES`` cannot get a CLI at all -- the
+structural fix that makes the ``ontology`` drift (no ``ops.SOURCES`` entry, no
+ledger row) impossible to repeat. No network.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from cdsci.lake import Settings, lake_connect, ops, upsert
+from cdsci.lake.sources._cli import build_app
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def lake_settings(tmp_path: Path) -> Settings:
+    return Settings(storage_base_uri=f"file://{tmp_path}")
+
+
+def _stub_ingest(lake_settings: Settings):
+    """A minimal ``ingest(**kwargs) -> dict`` shaped exactly like a real source's:
+    self-connects, self-brackets in ``ops.run``, returns ``r.summary()``."""
+
+    def ingest(*, schema: str = "bioregistry", limit: int | None = None) -> dict:
+        con = lake_connect(lake_settings)
+        try:
+            target = f"lake.{schema}.stub"
+            with ops.run(con, source="bioregistry", target=target, version="v1") as r:
+                src = f"SELECT * FROM (VALUES (1)) v(id) {'LIMIT ' + str(limit) if limit else ''}"
+                r.rows = upsert(con, target, src, key="id")
+            return r.summary()
+        finally:
+            con.close()
+
+    return ingest
+
+
+def test_build_app_rejects_a_name_not_in_sources():
+    """A source absent from ops.SOURCES can't get a CLI -- the structural fix."""
+    with pytest.raises(ValueError, match="not registered in ops.SOURCES"):
+        build_app("not_a_real_source", lambda **kwargs: {}, help="x")
+
+
+def test_run_options_are_generated_from_ingest_signature(lake_settings: Settings):
+    """--help lists exactly the stub's own kwargs (not a hand-written guess)."""
+    app = build_app("bioregistry", _stub_ingest(lake_settings), help="x")
+    result = runner.invoke(app, ["run", "--help"])
+    assert result.exit_code == 0
+    assert "--schema" in result.output
+    assert "--limit" in result.output
+    # `settings` is driver-injected, never a CLI option.
+    assert "--settings" not in result.output
+
+
+def test_run_command_calls_ingest_and_produces_a_ledger_row(lake_settings: Settings):
+    """The generated `run` command is a pass-through: ingest()'s own ops.run bracket
+    is what lands the ledger row -- the driver doesn't (and shouldn't) re-implement it."""
+    app = build_app("bioregistry", _stub_ingest(lake_settings), help="x")
+    result = runner.invoke(app, ["run", "--schema", "bioregistry"])
+    assert result.exit_code == 0, result.output
+    assert "changed" in result.output
+
+    con = lake_connect(lake_settings)
+    try:
+        last = ops.last_run(con, "bioregistry")
+        assert last is not None
+        assert last["status"] == "success"
+        assert last["target"] == "lake.bioregistry.stub"
+    finally:
+        con.close()
+
+
+def test_run_command_reports_idempotent_rerun(lake_settings: Settings):
+    """A second identical run echoes 'no change' -- the generic echo reads ingest()'s
+    own summary dict (`changed`/`status`), not a source-specific format string."""
+    app = build_app("bioregistry", _stub_ingest(lake_settings), help="x")
+    runner.invoke(app, ["run"])
+    result = runner.invoke(app, ["run"])
+    assert result.exit_code == 0, result.output
+    assert "no change (idempotent)" in result.output

--- a/tests/test_sources_cli.py
+++ b/tests/test_sources_cli.py
@@ -14,12 +14,21 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from typer.main import get_command
 from typer.testing import CliRunner
 
 from cdsci.lake import Settings, lake_connect, ops, upsert
 from cdsci.lake.sources._cli import build_app
 
 runner = CliRunner()
+
+
+def _run_option_names(app) -> set[str]:
+    """Real option flags for the generated `run` command, via click's own param
+    list -- not rendered `--help` text, which rich wraps at the terminal's
+    width and can split a flag across lines in a narrower CI terminal."""
+    run_cmd = get_command(app).commands["run"]
+    return {opt for param in run_cmd.params for opt in param.opts}
 
 
 @pytest.fixture
@@ -52,14 +61,17 @@ def test_build_app_rejects_a_name_not_in_sources():
 
 
 def test_run_options_are_generated_from_ingest_signature(lake_settings: Settings):
-    """--help lists exactly the stub's own kwargs (not a hand-written guess)."""
+    """`run`'s options are exactly the stub's own kwargs (not a hand-written guess)."""
     app = build_app("bioregistry", _stub_ingest(lake_settings), help="x")
+    opts = _run_option_names(app)
+    assert "--schema" in opts
+    assert "--limit" in opts
+    # `settings` is driver-injected, never a CLI option.
+    assert "--settings" not in opts
+
+    # --help itself still exits cleanly, regardless of terminal-width wrapping.
     result = runner.invoke(app, ["run", "--help"])
     assert result.exit_code == 0
-    assert "--schema" in result.output
-    assert "--limit" in result.output
-    # `settings` is driver-injected, never a CLI option.
-    assert "--settings" not in result.output
 
 
 def test_run_command_calls_ingest_and_produces_a_ledger_row(lake_settings: Settings):


### PR DESCRIPTION
## Summary

- 13 of 14 `sources/*/__main__.py` restated the same typer app + `--log-level` callback + `configure()` + `run` command + summary-echo shell around a source's own `ingest()`. Add `src/cdsci/lake/sources/_cli.py`: `build_app(name, ingest, *, help)` generates the `run` command from `ingest()`'s **real signature** (`inspect.signature` + `typing.get_type_hints`, since every `ingest.py` has `from __future__ import annotations`), and refuses to build a CLI at all for a `name` not present in `ops.SOURCES`.
- Fixes the live defect the issue is about: `ontology.ingest()` never wrapped itself in `ops.run` and was absent from `ops.SOURCES`, so its loads left no ledger row / no attributed snapshot. It's now registered in `SOURCES` and self-brackets in `ops.run(...)` exactly like the other 13 sources — this is the acceptance test for the issue.
- 10 sources' `run` command is now fully generated: `icite`, `ctgov`, `pmc`, `europepmc`, `census_geo`, `reliance`, `retractionwatch`, `bugsigdb`, `bioregistry`, `ontology`. Each keeps its own hand-written discovery subcommands (`icite latest`, `ctgov count`, `pmc ranges`, `europepmc databases`, `census_geo layers`, `ontology list`/`tables`) attached to the generated app.
- 3 sources keep a genuinely hand-written `run` (or multiple entrypoints), but build on the shared `base_app()` for the `--log-level` shell instead of restating it too: `mesh` (5 real entrypoints: `run`/`headings`/`chemicals`/`supplemental`/`actions`), `scp` (`run` parses `--file domain=path` into a dict before calling `ingest()` — a shape typer/click can't introspect), `openalex` (`parts`/`entities`/`works`, with `entities` sharing one connection across a loop of `ingest_entity(..., con=con)` calls — `con` must never become a CLI option).
- `reporter` was originally converted to the generated form too, but `ingest()`'s `files: list[str] | str | None` is a 3-way union typer/click can't turn into a single CLI option (`AssertionError: Typer Currently doesn't support Union types`) — reverted to hand-written, on `base_app()`.

## Design decisions

- **Introspection-based option generation**: `build_app` builds the `run` command's signature straight from `ingest()`'s own keyword parameters (dropping `settings`/`con` — driver-injected, never CLI-facing), so a new source's CLI options fall out of its function signature for free. Verified: `python -m cdsci.lake.sources.icite run --help` lists `--file`/`--version`/`--schema`/`--limit` derived from `icite.ingest()`'s real signature, not a hand-copied guess.
- **`ops.Source.ingest` is `Callable | None`, but `ops.SOURCES` doesn't populate it.** The issue's example snippet shows `ingest=` set directly on each `Source(...)` in `SOURCES`. I didn't do that: `ops.py` is imported by the base `cdsci.lake` package (the read-client surface — no ingest deps installed by a plain `pip install cdsci-lake`), and every `sources/*/ingest.py` does `from ... import ops` — importing all 14 ingest modules from inside `ops.py` would both violate that packaging boundary and create an import cycle. Instead, `build_app` looks a source up by name in `ops.SOURCES` and attaches the already locally-imported `ingest` via `dataclasses.replace` at CLI-build time. The structural fix survives intact: a `name` absent from `ops.SOURCES` still can't get a CLI (`build_app` raises `ValueError`), which is what closes off the drift `ontology` fell into.
- **`python -m cdsci.lake.sources.<name>` invocation shape is unchanged.** Grepped the repo and `~/Documents/git/monode/infrastructure/` — `systemd/icite.service` and `systemd/retractionwatch.service` (live systemd --user timers) both run `python -m cdsci.lake.sources.<name> run`, and `SCHEDULING.md`/`README.md` reference the same shape. Rather than inventing a new uniform `python -m cdsci.lake.sources <name> run` entrypoint (which the issue floats as an option), each source keeps its own thin `__main__.py` built on the shared driver — no scheduling/systemd changes needed.
- **Generic summary echo.** Every source's `ingest()` already returns `{**ops.Run.summary(), ...extras}` (verified across all 14 `ingest.py` files) — `table`/`rows`/`changed`/`status` are always present. `_echo_summary` prints one generic line from those instead of each source's bespoke format string; per-domain detail (e.g. `scp`'s per-domain row counts) stays in the sources that kept a hand-written `run`.

## Test plan

- `uv run ruff check src/ tests/` — clean.
- `uv run pytest -q` — 65 passed, 3 skipped (network-gated, as expected).
- New `tests/test_sources_cli.py`: `build_app` rejects a name not in `ops.SOURCES`; generated `--help` reflects a stub `ingest()`'s real kwargs (and excludes `settings`); the generated `run` command calls through to `ingest()` and produces a `lake_ops.run` ledger row; a second identical run reports `no change (idempotent)`.
- Extended `tests/test_ontology.py`: `ontology` is a member of `ops.SOURCES`; `ontology.ingest()` (with `available_ontologies`/`fetch_db` monkeypatched, no network) now brackets itself in `ops.run` and produces a ledger row attributed to `cdsci:ontology` — the issue's acceptance test.
- Manually verified `--help` for every generated source (`icite`, `ctgov`, `pmc`, `europepmc`, `census_geo`, `reliance`, `retractionwatch`, `bugsigdb`, `bioregistry`, `ontology`) and confirmed the three bespoke apps (`mesh`, `scp`, `openalex`) still list their existing subcommands.

Closes #52