### PR TITLE
Fix UniProt source: land the whole idmapping dump, not per-organism

### DIFF
--- a/src/cdsci/lake/config.py
+++ b/src/cdsci/lake/config.py
@@ -180,18 +180,23 @@ class Settings(BaseSettings):
         "exports/registry/registry.tsv"
     )
 
-    # UniProt ID mapping — organism-scoped ``*_idmapping_selected.tab.gz`` dumps
-    # (CC BY 4.0, confirmed at uniprot.org/help/license 2026-08-11), tab-delimited,
-    # no header, 22 columns per UniProt's own README (UniProtKB-AC, UniProtKB-ID,
-    # GeneID, ... see ``sources/uniprot/ingest.py``). "current_release" has no
-    # version tag in the URL, so (like retractionwatch) we tag the snapshot by
-    # pull date. Only the human file is loaded by default; ``ingest(organisms=...)``
-    # takes any other ``by_organism/`` filename stem.
-    uniprot_idmapping_base_url: str = (
+    # UniProt ID mapping — the single un-split whole-of-UniProt ``idmapping_selected
+    # .tab.gz`` dump (CC BY 4.0, confirmed at uniprot.org/help/license 2026-08-11),
+    # tab-delimited, no header, 22 columns per UniProt's own README (UniProtKB-AC,
+    # UniProtKB-ID, GeneID, ... see ``sources/uniprot/ingest.py``). NOT the
+    # per-organism ``idmapping/by_organism/`` files — that directory only covers a
+    # curated reference set (not UniProt's full breadth) and taxon-scoping the
+    # *load* violates the lake's "land raw whole" convention; ``ncbi_taxon`` is
+    # already a per-row column in the un-split file. "current_release" has no
+    # version tag in the URL, so (like retractionwatch) we tag the snapshot by pull
+    # date. ~6.6 GiB gzipped (confirmed via HEAD against the ftp.expasy.org /
+    # ftp.ebi.ac.uk mirrors, 2026-08-11 — ftp.uniprot.org itself times out
+    # intermittently for large GETs in this environment); ``ingest(batches=...)``
+    # shards the load to bound peak memory (see ``sources/uniprot/ingest.py``).
+    uniprot_idmapping_url: str = (
         "https://ftp.uniprot.org/pub/databases/uniprot/current_release/"
-        "knowledgebase/idmapping/by_organism/"
+        "knowledgebase/idmapping/idmapping_selected.tab.gz"
     )
-    uniprot_organisms: list[str] = ["HUMAN_9606"]
 
     # --- Reverse-ETL: publish to bioc-on-ice's Iceberg catalog via icegate ---
     # bioc-on-ice is a *publication* layer (ADR-0015 §"iceberg target"): the

--- a/src/cdsci/lake/ops.py
+++ b/src/cdsci/lake/ops.py
@@ -116,7 +116,7 @@ SOURCES: tuple[Source, ...] = (
            "annual", "zenodo", "cc-by-nc-4.0"),
     Source("bioregistry", "ref", "Bioregistry: canonical identifier prefixes, patterns, synonyms",
            "weekly", "github-tsv", "cc0"),
-    Source("uniprot", "uniprot", "UniProt organism-scoped accession<->EntrezGene ID mapping",
+    Source("uniprot", "uniprot", "UniProt accession<->EntrezGene ID mapping (whole dump)",
            "~8-weekly", "uniprot-ftp", "cc-by-4.0"),
     Source("ontology", "ontology", "OBO semantic-sql builds: terms/synonyms/xrefs/edges",
            "on-release", "semsql-s3", "mixed"),

--- a/src/cdsci/lake/sources/uniprot/__init__.py
+++ b/src/cdsci/lake/sources/uniprot/__init__.py
@@ -1,7 +1,9 @@
-"""UniProt — accession ↔ EntrezGene ID mapping (organism-scoped bulk dumps).
+"""UniProt — accession ↔ EntrezGene ID mapping (whole-of-UniProt bulk dump).
 
 One tidy table ``lake.uniprot.idmapping`` keyed ``(accession, gene_id)`` — GeneID
-is many-to-many with UniProtKB-AC, so the pair is the natural key. Feeds
+is many-to-many with UniProtKB-AC, so the pair is the natural key. Loaded from
+UniProt's single un-split ``idmapping_selected.tab.gz`` (not the per-organism
+``by_organism/`` files — see ``ingest.py``'s module docstring for why). Feeds
 bioc-on-ice's ``annotation.identifier_mapping`` (``ENTREZID``<->``UNIPROT``) via
 the same reverse-ETL path BugSigDB uses, once that publish path is unblocked
 (cdsci-lake#32, cdsci-lake#53).

--- a/src/cdsci/lake/sources/uniprot/ingest.py
+++ b/src/cdsci/lake/sources/uniprot/ingest.py
@@ -1,16 +1,25 @@
-"""Ingest UniProt's organism-scoped ID-mapping dumps into ``lake.uniprot.idmapping``.
+"""Ingest UniProt's whole-of-UniProt ID-mapping dump into ``lake.uniprot.idmapping``.
 
-UniProt publishes one ``<ORGANISM>_idmapping_selected.tab.gz`` per organism under
-``idmapping/by_organism/`` — tab-delimited, **no header**, 22 columns per
-UniProt's own README:
+UniProt publishes one un-split ``idmapping_selected.tab.gz`` covering **every**
+UniProtKB entry regardless of organism — tab-delimited, **no header**, 22 columns
+per UniProt's own README:
 
     UniProtKB-AC, UniProtKB-ID, GeneID (EntrezGene), RefSeq, GI, PDB, GO,
     UniRef100, UniRef90, UniRef50, UniParc, PIR, NCBI-taxon, MIM, UniGene,
     PubMed, EMBL, EMBL-CDS, Ensembl, Ensembl_TRS, Ensembl_PRO, Additional PubMed
 
+An earlier version of this source downloaded per-organism files under
+``idmapping/by_organism/`` instead. That was a scoping mistake (issue #32
+follow-up): the lake's standing convention is "land raw whole," and
+``by_organism/`` only covers a curated reference set anyway — not UniProt's full
+breadth — so even looping over every file there wouldn't have been "whole."
+``ncbi_taxon`` is already a per-row column in the un-split file, so nothing about
+per-organism filtering is lost by dropping the split; it's just done downstream
+(a view / WHERE clause) instead of at ingest time.
+
 Only column 1 (accession) and column 3 (GeneID) feed the mapping this source
-exists for — the rest land unused, per the "land raw whole" convention (issue
-#32): don't drop columns just because nothing reads them yet.
+exists for — the rest land unused, per the "land raw whole" convention: don't
+drop columns just because nothing reads them yet.
 
 GeneID is itself ``;``-separated when one UniProt entry maps to more than one
 Entrez gene, and a GeneID can just as easily map back to more than one
@@ -18,6 +27,19 @@ accession — so neither column alone is a key. Each row is exploded to one
 ``(accession, gene_id)`` pair, which **is** the natural key (MERGE-upsert,
 ADR-0003). ``current_release`` carries no version in the URL (like
 retractionwatch's rolling CSV), so the snapshot is tagged by pull date.
+
+The un-split dump is ~6.6 GiB gzipped (confirmed via HEAD against the
+ftp.expasy.org / ftp.ebi.ac.uk mirrors, 2026-08-11 — ftp.uniprot.org itself
+times out intermittently for large GETs in this environment) — multi-GB, same
+order of magnitude as the PMC bulk load. Since it's one un-splittable gzip
+stream (no random access), ``ingest(batches=...)`` shards the *load* (not the
+download — that still happens once) by ``hash(accession) % batches`` so no
+single pass materializes the whole exploded result set at once, the same
+memory-bounding lever ``openalex`` uses for its part-file batches and ``pmc``
+uses for its passage-shard batches. ``mode="append"`` (vs the default
+``"merge"``) additionally skips each batch's MERGE-read of the growing target —
+valid because batches partition disjointly by accession, so it's safe for the
+initial bulk load the same way it is for openalex/pmc.
 
 License: CC BY 4.0 (confirmed at https://www.uniprot.org/help/license,
 2026-08-11) — carried forward via ``ops.SOURCES``.
@@ -65,20 +87,29 @@ def _gene_ids(col: str) -> str:
     )
 
 
-def download_idmapping(organism: str, version: str, settings: Settings | None = None) -> Path:
-    """Download one organism's ID-mapping file into the raw layer (kept as bronze)."""
+def download_idmapping(version: str, settings: Settings | None = None) -> Path:
+    """Download the whole-of-UniProt ID-mapping dump into the raw layer (kept as bronze)."""
     s = settings or get_settings()
-    filename = f"{organism}_idmapping_selected.tab.gz"
-    dest = raw_dir(_RAW, s) / f"{version}-{filename}"
-    return download(f"{s.uniprot_idmapping_base_url}{filename}", dest)
+    dest = raw_dir(_RAW, s) / f"{version}-idmapping_selected.tab.gz"
+    return download(s.uniprot_idmapping_url, dest)
 
 
-def _select_sql(path: Path, organism: str, version: str, limit: int | None) -> str:
-    limit_sql = f" LIMIT {int(limit)}" if limit else ""
+def _select_sql(
+    path: Path, version: str, limit: int | None, batch: tuple[int, int] | None = None
+) -> str:
+    """Render the curate SELECT; ``batch=(i, n)`` keeps only the ``i``-th of ``n``
+    ``hash(accession)``-mod shards — the memory-bounding lever (see module docstring).
+    """
     columns_sql = ", ".join(f"'{c}': 'VARCHAR'" for c in _COLUMNS)
     passthrough = ", ".join(
         f'trim("{c}") AS {c}' for c in _COLUMNS if c not in ("accession", "gene_id_raw")
     )
+    where = ["trim(accession) <> ''", "TRY_CAST(gid AS BIGINT) IS NOT NULL"]
+    if batch is not None:
+        i, n = batch
+        where.append(f"(hash(accession) % {int(n)}) = {int(i)}")
+    where_sql = " AND ".join(where)
+    limit_sql = f" LIMIT {int(limit)}" if limit else ""
     return f"""
         WITH raw AS (
             SELECT * FROM read_csv(
@@ -92,59 +123,94 @@ def _select_sql(path: Path, organism: str, version: str, limit: int | None) -> s
             trim(accession)                       AS accession,
             TRY_CAST(gid AS BIGINT)                AS gene_id,
             {passthrough},
-            CAST({_sql_str(organism)} AS VARCHAR)  AS organism,
             CAST({_sql_str(version)} AS VARCHAR)   AS snapshot_version
         FROM raw, UNNEST({_gene_ids("gene_id_raw")}) AS t(gid)
-        WHERE trim(accession) <> '' AND TRY_CAST(gid AS BIGINT) IS NOT NULL{limit_sql}
+        WHERE {where_sql}{limit_sql}
     """
+
+
+def _load(
+    con: duckdb.DuckDBPyConnection,
+    target: str,
+    source_sql: str,
+    key: list[str],
+    *,
+    mode: str,
+) -> int:
+    """Dispatch one batch to MERGE-upsert (idempotent) or append-INSERT (disjoint bulk).
+
+    ``mode="merge"`` (default) MERGE-upserts on ``key`` — safe for reruns/top-ups.
+    ``mode="append"`` INSERTs without reading the target — for the initial bulk,
+    whose accession-hash batches are disjoint, so a MERGE's whole-table read
+    (growing every batch) is pure waste (the lesson from ``openalex``/``pmc``).
+    """
+    if mode == "merge":
+        return upsert(con, target, source_sql, key, exclude_change_cols=["snapshot_version"])
+    if mode != "append":
+        raise ValueError(f"mode must be 'merge' or 'append', got {mode!r}")
+    catalog, schema, _ = target.split(".")
+    con.execute(f"CREATE SCHEMA IF NOT EXISTS {catalog}.{schema};")
+    con.execute(f"CREATE OR REPLACE TEMP TABLE _up_stage AS {source_sql};")
+    con.execute(f"CREATE TABLE IF NOT EXISTS {target} AS SELECT * FROM _up_stage WHERE false;")
+    con.execute(f"INSERT INTO {target} SELECT * FROM _up_stage;")
+    return con.execute(f"SELECT count(*) FROM {target}").fetchone()[0]
 
 
 def curate(
     con: duckdb.DuckDBPyConnection,
     path: Path,
-    organism: str,
     version: str,
     *,
     target: str | None = None,
     limit: int | None = None,
+    batch: tuple[int, int] | None = None,
+    mode: str = "merge",
 ) -> int:
-    """MERGE-upsert one organism's file into ``idmapping``, keyed ``(accession, gene_id)``."""
+    """Load one batch of the idmapping file, keyed ``(accession, gene_id)``.
+
+    Returns the target's current full row count (see :func:`_load`).
+    """
     target = target or f"{LAKE}.{_TABLE}"
-    return upsert(
-        con, target, _select_sql(path, organism, version, limit),
-        key=["accession", "gene_id"], exclude_change_cols=["snapshot_version"],
+    return _load(
+        con, target, _select_sql(path, version, limit, batch),
+        key=["accession", "gene_id"], mode=mode,
     )
 
 
 def ingest(
     *,
-    organisms: list[str] | None = None,
     file: str | None = None,
     version: str | None = None,
     schema: str = "uniprot",
     limit: int | None = None,
+    batches: int = 20,
+    mode: str = "merge",
     settings: Settings | None = None,
 ) -> dict:
-    """End-to-end: download each organism's file (unless ``file``) → MERGE-upsert → summary.
+    """End-to-end: download the whole-of-UniProt dump (unless ``file``) → batched load → summary.
 
-    ``organisms`` defaults to :attr:`Settings.uniprot_organisms` (human only).
-    ``file`` overrides the download for every organism in the loop with one
-    local path — the single-organism/local-fixture case (see ``census_geo``,
-    ``reliance`` for the same idiom).
+    ``batches`` shards the load by ``hash(accession) % batches`` to bound peak
+    memory on the ~6.6 GiB gzip source (see module docstring); 1 disables sharding.
+    ``mode="append"`` is valid (and faster) for the initial bulk load since batches
+    are disjoint by accession — see :func:`_load`. ``file`` overrides the download
+    with one local path — the local-fixture case (see ``census_geo``, ``reliance``
+    for the same idiom).
     """
     s = settings or get_settings()
     version = version or _today_version()
-    orgs = organisms or list(s.uniprot_organisms)
     target = f"{LAKE}.{schema}.idmapping"
 
     con = lake_connect(s)
     try:
-        counts: dict[str, int] = {}
         with ops.run(con, source="uniprot", target=target, version=version) as r:
-            for organism in orgs:
-                path = Path(file) if file else download_idmapping(organism, version, s)
-                counts[organism] = curate(con, path, organism, version, target=target, limit=limit)
-            r.rows = con.execute(f"SELECT count(*) FROM {target}").fetchone()[0]
+            path = Path(file) if file else download_idmapping(version, s)
+            rows = 0
+            for i in range(batches):
+                shard = (i, batches) if batches > 1 else None
+                rows = curate(
+                    con, path, version, target=target, limit=limit, batch=shard, mode=mode
+                )
+            r.rows = rows
     finally:
         con.close()
-    return {**r.summary(), "counts": counts}
+    return r.summary()

--- a/tests/test_uniprot.py
+++ b/tests/test_uniprot.py
@@ -1,10 +1,11 @@
 """Offline tests for the UniProt ID-mapping source.
 
-Curate the tab-delimited, headerless idmapping_selected fixture into the tidy
+Curate the tab-delimited, headerless idmapping_selected fixture (the whole-of-
+UniProt shape — not organism-scoped, issue #32 follow-up) into the tidy
 ``uniprot.idmapping`` table: multi-valued GeneID explodes to one row per
 (accession, gene_id) pair, an accession with no GeneID drops, unused columns
-land raw, MERGE idempotency, and the CC BY 4.0 license carries forward in
-lake_ops. No network.
+land raw, MERGE idempotency, batch sharding, append mode, and the CC BY 4.0
+license carries forward in lake_ops. No network.
 """
 
 from __future__ import annotations
@@ -33,17 +34,15 @@ def test_uniprot_curate(lake_settings: Settings):
 
         # 3 fixture rows: P04637 (1 GeneID), P01308 (2 GeneIDs, explodes to 2
         # rows), Q9UNQ0 (no GeneID, drops entirely) -> 3 pairs.
-        n = uniprot.curate(
-            con, FIXTURES / "uniprot_idmapping_sample.tab", "HUMAN_9606", "test-2026-08-11"
-        )
+        n = uniprot.curate(con, FIXTURES / "uniprot_idmapping_sample.tab", "test-2026-08-11")
         assert n == 3
         assert table_exists(con, "idmapping")
 
         row = con.execute("""
-            SELECT gene_id, uniprotkb_id, refseq, ncbi_taxon, organism
+            SELECT gene_id, uniprotkb_id, refseq, ncbi_taxon
             FROM lake.uniprot.idmapping WHERE accession = 'P04637'
         """).fetchone()
-        assert row == (7157, "P53_HUMAN", "NM_000546.6", "9606", "HUMAN_9606")
+        assert row == (7157, "P53_HUMAN", "NM_000546.6", "9606")
 
         # Many-to-many: one accession, two exploded (accession, gene_id) rows.
         gene_ids = {
@@ -65,11 +64,36 @@ def test_uniprot_curate(lake_settings: Settings):
 
         # Idempotent re-run adds no snapshot.
         before = con.execute("SELECT max(snapshot_id) FROM lake.snapshots()").fetchone()[0]
-        uniprot.curate(
-            con, FIXTURES / "uniprot_idmapping_sample.tab", "HUMAN_9606", "test-2026-08-11"
-        )
+        uniprot.curate(con, FIXTURES / "uniprot_idmapping_sample.tab", "test-2026-08-11")
         after = con.execute("SELECT max(snapshot_id) FROM lake.snapshots()").fetchone()[0]
         assert before == after
+    finally:
+        con.close()
+
+
+def test_uniprot_curate_batched(lake_settings: Settings):
+    """``batch=(i, n)`` shards by ``hash(accession)`` — every shard together == unsharded."""
+    con = lake_connect(lake_settings)
+    try:
+        ops.register_sources(con, writer="cdsci", sources=ops.SOURCES)
+        path = FIXTURES / "uniprot_idmapping_sample.tab"
+        n_shards = 4
+        for i in range(n_shards):
+            uniprot.curate(con, path, "test-2026-08-11", batch=(i, n_shards))
+        assert con.execute("SELECT count(*) FROM lake.uniprot.idmapping").fetchone()[0] == 3
+    finally:
+        con.close()
+
+
+def test_uniprot_curate_append_mode(lake_settings: Settings):
+    """``mode='append'`` skips the MERGE and just INSERTs — used for the disjoint bulk load."""
+    con = lake_connect(lake_settings)
+    try:
+        ops.register_sources(con, writer="cdsci", sources=ops.SOURCES)
+        path = FIXTURES / "uniprot_idmapping_sample.tab"
+        n = uniprot.curate(con, path, "test-2026-08-11", mode="append")
+        assert n == 3
+        assert con.execute("SELECT count(*) FROM lake.uniprot.idmapping").fetchone()[0] == 3
     finally:
         con.close()
 
@@ -77,11 +101,10 @@ def test_uniprot_curate(lake_settings: Settings):
 def test_uniprot_ingest_end_to_end(lake_settings: Settings):
     """``ingest(file=...)`` self-connects, brackets in ops.run, returns a summary."""
     summary = uniprot.ingest(
-        organisms=["HUMAN_9606"],
         file=str(FIXTURES / "uniprot_idmapping_sample.tab"),
         version="test-2026-08-11",
+        batches=1,
         settings=lake_settings,
     )
     assert summary["rows"] == 3
     assert summary["status"] == "success"
-    assert summary["counts"] == {"HUMAN_9606": 3}


### PR DESCRIPTION
## Summary

The just-merged UniProt source (#32) had a scoping mistake: `ingest()` defaulted to downloading organism-scoped `<ORGANISM>_idmapping_selected.tab.gz` files from `idmapping/by_organism/`, defaulting to human only. This lake's standing convention is "land raw whole" — other sources (openalex, census_geo, pmc) don't taxon-limit. `by_organism/` also only covers a curated reference set, not UniProt's full breadth, so even looping over every file there wouldn't have been "whole."

- Switch to the single un-split `idmapping_selected.tab.gz`, covering every UniProtKB entry regardless of organism (same 22-column tab format, no header).
- Remove the `organisms` parameter/loop and the per-download `organism` column — `ncbi_taxon` is already a per-row column in the file, so nothing about per-organism filtering is lost; it's just done downstream instead of at ingest time.
- Remove `Settings.uniprot_organisms` / rename `uniprot_idmapping_base_url` → `uniprot_idmapping_url` (points at the single file, not the `by_organism/` directory).
- Confirmed real file size via HEAD (see below) — it's multi-GB, so:
  - `ingest(batches=...)` shards the load by `hash(accession) % batches` so no single pass materializes the whole exploded result set (default 20 batches).
  - `mode="append"` (vs default `"merge"`) skips the MERGE-read of the growing target for the initial bulk, since accession-hash batches are disjoint — both levers lifted directly from `openalex`/`pmc`'s existing pattern for the same problem at the same scale.
- Updated `tests/test_uniprot.py` for the new (no-organism) signature, plus new coverage for batch sharding and append mode.
- No `models/uniprot/identifier_mapping.sql` exists in this repo (the reverse-ETL/bioc-on-ice publish path was deliberately deferred in the original PR — see its commit message), so there was nothing to update there.

## File size confirmation

`ftp.uniprot.org` itself timed out on repeated HEAD attempts in this environment (matches the known intermittent-stall issue). Two independent mirrors agreed exactly:
- `ftp.expasy.org`: `Content-Length: 7066467385` (~6.58 GiB)
- `ftp.ebi.ac.uk`: `Content-Length: 7066467385`, same `ETag` pattern

So ~6.6 GiB gzipped, confirmed (not assumed) — this is what justified the batching approach rather than a naive single-shot load.

## Real-byte validation

Also pulled a real ~2 MB byte-range slice of the actual `idmapping_selected.tab.gz` from `ftp.ebi.ac.uk` and ran the ingest SQL against it directly (not just the hand-built fixture): 14,319 raw real rows → 7,756 exploded `(accession, gene_id)` rows, identical whether loaded unsharded (merge) or as 8 disjoint `batch=(i,8)` shards in append mode. Real format matched the hand-built fixture's shape exactly.

## Test plan
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run pytest -q` — 69 passed, 3 skipped (pre-existing network/GSM-gated tests, unrelated to this change)
- [x] Verified against real UniProt bytes (see above), not just the fixture

Related to #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FposEN8ErZTLzsjTfSdZjj