### PR TITLE
Add uniprot.identifier_mapping transform model

### DIFF
--- a/models/uniprot/identifier_mapping.sql
+++ b/models/uniprot/identifier_mapping.sql
@@ -1,0 +1,25 @@
+-- description: UniProt accession<->Entrez gene ID mapping, shaped for bioc-on-ice's annotation.identifier_mapping (cdsci-lake#32).
+-- license: cc-by-4.0
+-- uniprot.identifier_mapping: reshapes lake.uniprot.idmapping's (accession,
+-- gene_id) pairs into the (source_namespace, source_id, target_namespace,
+-- target_id, taxon_id, source, confidence, valid_from, valid_to) tuple
+-- bioc-on-ice's annotation.identifier_mapping already uses for every other
+-- cross-reference direction (verified live: ENTREZ -> SYMBOL/ALIAS/HGNC/...).
+-- `ENTREZ`, not `ENTREZID` -- the OrgDb keytype name (SPEC.md's own parity
+-- list) and the identifier_mapping namespace value differ; checked the live
+-- table before writing this, not assumed from the keytype list.
+-- `taxon_id` is UniProt's own per-row NCBI-taxon column, not inferred from
+-- which organism file the row was downloaded from -- more precise if a
+-- future multi-organism load ever mixes files.
+SELECT
+    'ENTREZ' AS source_namespace,
+    CAST(gene_id AS VARCHAR) AS source_id,
+    'UNIPROT' AS target_namespace,
+    accession AS target_id,
+    TRY_CAST(ncbi_taxon AS INTEGER) AS taxon_id,
+    'UniProt' AS source,
+    CAST(NULL AS DOUBLE) AS confidence,
+    snapshot_version AS valid_from,
+    CAST(NULL AS VARCHAR) AS valid_to
+FROM lake.uniprot.idmapping
+WHERE TRY_CAST(ncbi_taxon AS INTEGER) IS NOT NULL

--- a/models/uniprot/identifier_mapping.test.sql
+++ b/models/uniprot/identifier_mapping.test.sql
@@ -1,0 +1,3 @@
+-- test: (source_id, target_id) is unique
+SELECT source_id, target_id FROM lake.uniprot.identifier_mapping
+GROUP BY source_id, target_id HAVING count(*) > 1


### PR DESCRIPTION
## Summary
- Shapes `lake.uniprot.idmapping` into bioc-on-ice's `annotation.identifier_mapping` tuple shape (`source_namespace`/`source_id`/`target_namespace`/`target_id`/`taxon_id`/`source`/`confidence`/`valid_from`/`valid_to`)
- `ENTREZ`, not `ENTREZID` — checked the live bioc-on-ice table's actual namespace vocabulary before writing this, rather than assuming from the OrgDb keytype list
- Written and run against prod earlier this session (verified: 34,223 rows, uniqueness test passed) but never committed — closing that gap now
- Not published/reverse-ETL'd — that's on hold pending #63 (unscoped-delete bug) and general direction to focus on cdsci-lake-side work first

## Test plan
- [x] `uv run pytest tests/test_transform.py -q` — 13 passed
- [x] Ran `transform run uniprot.identifier_mapping` against prod earlier — 34,223 rows, `(source_id, target_id)` uniqueness test passed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FposEN8ErZTLzsjTfSdZjj