### PR TITLE
Fix upsert idempotency for NULL key columns

### DIFF
--- a/src/cdsci/lake/connect.py
+++ b/src/cdsci/lake/connect.py
@@ -273,6 +273,10 @@ def upsert(
     point of time-travel. A bulk ``CREATE OR REPLACE`` would instead make every
     snapshot a full rewrite.
 
+    That guarantee holds for **NULL key columns too**: the MERGE join is
+    ``IS NOT DISTINCT FROM``, so a key whose value is legitimately absent still
+    matches its existing row instead of re-INSERTing every load (#71).
+
     ``exclude_change_cols`` are columns set on update (via ``UPDATE SET *``) but
     **ignored** in the change predicate — for per-load stamps like
     ``snapshot_version`` that differ on every load. Without this, such a column
@@ -306,7 +310,13 @@ def upsert(
 
         cols = [c[0] for c in con.execute("DESCRIBE _cri_stage").fetchall()]
         compare = [c for c in cols if c not in keys and c not in ignore]
-        on = " AND ".join(f"t.{k} = s.{k}" for k in keys)
+        # IS NOT DISTINCT FROM, not `=`: a NULL key column is a real value here
+        # (NCBI writes `-` for "no RNA/protein product", which nullstr turns into
+        # NULL, and that NULL is part of gene2ensembl's natural key). Under plain
+        # `=`, NULL = NULL is NULL rather than true, so such a row never matches
+        # an existing one and re-INSERTs on every load — unbounded duplication,
+        # silently, for exactly the sources whose keys are widest (#71).
+        on = " AND ".join(f"t.{k} IS NOT DISTINCT FROM s.{k}" for k in keys)
         matched = ""
         if compare:
             changed = " OR ".join(f"t.{c} IS DISTINCT FROM s.{c}" for c in compare)

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -143,6 +143,40 @@ def test_upsert_excludes_metadata_from_change(lake_settings: Settings):
         con.close()
 
 
+def test_upsert_is_idempotent_for_null_key_columns(lake_settings: Settings):
+    """A NULL in a key column must still match its existing row, not re-INSERT.
+
+    Regression for #71: the MERGE join used plain ``=``, and ``NULL = NULL`` is
+    NULL rather than true, so a row whose key was legitimately absent never
+    matched and duplicated on every load. Real case: ``ncbi_gene.gene2ensembl``
+    keys on six columns including ``rna_accession``/``protein_accession``, which
+    NCBI leaves empty for genes with no RNA/protein product.
+    """
+    con = lake_connect(lake_settings)
+    try:
+        src = "SELECT * FROM (VALUES (1,'a','x'),(2,NULL,'y')) v(id,acc,val)"
+        keys = ["id", "acc"]
+        assert upsert(con, "lake.main.nk", src, key=keys) == 2
+        assert upsert(con, "lake.main.nk", src, key=keys) == 2
+        assert upsert(con, "lake.main.nk", src, key=keys) == 2
+
+        # The NULL-key row exists exactly once, not once per load.
+        n = con.execute("SELECT count(*) FROM lake.main.nk WHERE acc IS NULL").fetchone()[0]
+        assert n == 1
+
+        # And an unchanged re-run still makes no snapshot (the no-op-is-free contract).
+        before = con.execute("SELECT max(snapshot_id) FROM lake.snapshots()").fetchone()[0]
+        upsert(con, "lake.main.nk", src, key=keys)
+        assert con.execute("SELECT max(snapshot_id) FROM lake.snapshots()").fetchone()[0] == before
+
+        # A real change to the NULL-key row updates in place rather than adding one.
+        changed = "SELECT * FROM (VALUES (1,'a','x'),(2,NULL,'Y')) v(id,acc,val)"
+        assert upsert(con, "lake.main.nk", changed, key=keys) == 2
+        assert con.execute("SELECT val FROM lake.main.nk WHERE acc IS NULL").fetchone()[0] == "Y"
+    finally:
+        con.close()
+
+
 def test_reporter_projects_curate(lake_settings: Settings):
     con = lake_connect(lake_settings)
     try:


### PR DESCRIPTION
## Summary

`upsert()`'s MERGE join used plain equality on key columns. `NULL = NULL` is NULL, not true — so any row whose key column is legitimately absent never matched an existing row and fell through to `INSERT`, duplicating on **every** load, silently and without bound.

Changed to `IS NOT DISTINCT FROM`. Note this removes an internal inconsistency: the change-detection clause two lines below already used `IS DISTINCT FROM` correctly; only the join predicate was NULL-unsafe.

## Impact

`lake.ncbi_gene.gene2ensembl` is affected today — its six-column natural key includes `rna_accession` / `ensembl_rna_id` / `protein_accession` / `ensembl_protein_id`, which NCBI leaves empty (`-` → `nullstr` → NULL) for genes with no RNA or protein product. That table has not had a real prod load yet, so it should be clean; worth a duplicate check on any table that has.

This violated the invariant the repo treats as central — "an unchanged re-run adds no snapshot" — and that `ops.run`'s `idempotent` status reports against. An affected re-land would report `success`/changed and add duplicate rows instead of reporting `idempotent`.

## Test plan

- [x] New `test_upsert_is_idempotent_for_null_key_columns` — **verified to fail without the fix** (3 rows after two identical loads, asserting 2) and pass with it. Also covers: NULL-key row exists exactly once after three loads, an unchanged re-run still makes no snapshot, and a real change to the NULL-key row updates in place rather than appending.
- [x] `uv run --all-extras pytest -q` → 100 passed, 10 skipped — no existing source regressed on the changed shared semantics
- [x] `uv run ruff check src/ tests/` clean
- [ ] CI green

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FposEN8ErZTLzsjTfSdZjj