### PR TITLE
Add ORCID + ROR identity-authority sources (#56, #57, EL only)

### DIFF
--- a/docs/data-licenses.md
+++ b/docs/data-licenses.md
@@ -14,6 +14,8 @@ into it is internal use, not redistribution.
 | openalex | CC0 | yes | public domain dedication |
 | retractionwatch | CC0 (effectively) | yes | attribution appreciated |
 | reactome | CC0 | yes | reactome.org/license §1(c) covers the *data*; §1(a) CC BY 4.0 covers illustrations/icons only |
+| ror | CC0 | yes | ror.readme.io/docs/data-dump: "All ROR IDs and metadata in the data dump are provided under the Creative Commons CC0 1.0 Universal Public Domain Dedication"; Zenodo record carries `license: cc-zero` |
+| orcid | CC0 | yes | info.orcid.org/annual-data-files: "ORCID releases the Public Data File under a CC0 1.0 Public Domain Dedication". Same terms for the public API. Only researcher-*public* fields are returned; ORCID's Public Data File Use Policy adds community norms (cite ORCID, honor deletions on refresh), not license conditions |
 | pmc | mixed OA | per-article | BioC-PMC open-access subset; honor per-article terms |
 | europepmc | Europe PMC terms | verify | confirm reuse terms before any external sharing |
 | **reliance** | **CC BY-NC 4.0** | **NO** | **non-commercial only; do NOT redistribute; attribute Marx** |

--- a/src/cdsci/lake/config.py
+++ b/src/cdsci/lake/config.py
@@ -218,6 +218,21 @@ class Settings(BaseSettings):
     # is tagged by retrieval date. See ``sources/reactome/ingest.py``.
     reactome_base_url: str = "https://reactome.org/download/current/"
 
+    # ROR — the versioned institution-registry bulk dump (CC0, confirmed at
+    # ror.readme.io/docs/data-dump 2026-08-11). This is the Zenodo *concept*
+    # record: it always resolves to the newest release, whose `metadata.version`
+    # (`v2.11`) is the release's own tag — so unlike the rolling sources above,
+    # the snapshot is tagged by the dump, not the pull date (issue #57).
+    ror_zenodo_concept_record: str = "6347574"
+
+    # ORCID — the unauthenticated public API, deliberately *not* the annual bulk
+    # Public Data File (~863 GB of one-XML-per-record; see
+    # ``sources/orcid/ingest.py`` for the deviation and its numbers). CC0.
+    # `expanded-search` answers `orcid:(A OR B OR ...)`; 100 iDs per request is
+    # ~2.3 KB of query string and ~0.4 s, verified on a real batch.
+    orcid_api_base: str = "https://pub.orcid.org/v3.0"
+    orcid_batch_size: int = 100
+
     # --- Reverse-ETL: publish to bioc-on-ice's Iceberg catalog via icegate ---
     # bioc-on-ice is a *publication* layer (ADR-0015 §"iceberg target"): the
     # REST catalog gateway already exists, live in production, so this is

--- a/src/cdsci/lake/download.py
+++ b/src/cdsci/lake/download.py
@@ -26,10 +26,16 @@ _log = logger.bind(ctx="download")
     wait=wait_exponential(multiplier=2, max=60),
     reraise=True,
 )
-def get_json(url: str, *, params: dict | None = None) -> dict | list:
-    """GET and parse JSON, retrying transient HTTP errors."""
+def get_json(
+    url: str, *, params: dict | None = None, headers: dict | None = None
+) -> dict | list:
+    """GET and parse JSON, retrying transient HTTP errors.
+
+    ``headers`` exists for APIs that content-negotiate: ``pub.orcid.org`` serves
+    XML to httpx's default ``Accept: */*`` and only returns JSON when asked.
+    """
     with httpx.Client(timeout=_TIMEOUT, follow_redirects=True) as client:
-        resp = client.get(url, params=params)
+        resp = client.get(url, params=params, headers=headers)
         resp.raise_for_status()
         return resp.json()
 

--- a/src/cdsci/lake/ops.py
+++ b/src/cdsci/lake/ops.py
@@ -144,6 +144,12 @@ SOURCES: tuple[Source, ...] = (
            "ensembl-no-restrictions"),
     Source("reactome", "reactome", "Reactome pathways: gene->pathway (all levels) + hierarchy",
            "quarterly", "reactome-download", "cc0"),
+    Source("ror", "ror", "ROR: canonical institution identity (names, locations, relationships)",
+           "on-release", "zenodo", "cc0"),
+    # Not the annual bulk file: demand-driven fetch of caller-supplied iDs from
+    # the public API (issue #56 -- see sources/orcid/ingest.py for the numbers).
+    Source("orcid", "orcid", "ORCID: canonical researcher identity (names + affiliations), "
+           "scoped to requested iDs", "on-demand", "orcid-public-api", "cc0"),
 )
 
 

--- a/src/cdsci/lake/sources/orcid/__init__.py
+++ b/src/cdsci/lake/sources/orcid/__init__.py
@@ -1,0 +1,19 @@
+"""ORCID — the canonical, CC0 researcher-identity authority (issue #56).
+
+One raw landing table, ``lake.orcid.person``, keyed on ``orcid_id``.
+
+**Not** the annual bulk Public Data File: that is ~863 GB of one-XML-file-per-
+record with no scannable artifact, and nothing in this lake carries an ORCID iD
+to join it against yet. This EL is demand-driven — hand it the iDs you have
+(``orcids=`` or ``orcids_sql=``) and it batch-fetches them from the public API.
+The deviation and the measured numbers behind it are in ``ingest.py``.
+
+EL only: whether this ever reverse-ETLs to bioc-on-ice is the open question #56
+raises and does not settle; publishing is deferred per #63.
+
+License: CC0 (info.orcid.org/annual-data-files).
+"""
+
+from .ingest import COLUMNS, fetch, ingest, land, resolve_orcids
+
+__all__ = ["COLUMNS", "fetch", "ingest", "land", "resolve_orcids"]

--- a/src/cdsci/lake/sources/orcid/__main__.py
+++ b/src/cdsci/lake/sources/orcid/__main__.py
@@ -1,0 +1,18 @@
+"""CLI: ``python -m cdsci.lake.sources.orcid`` — land ORCID identity records."""
+
+from __future__ import annotations
+
+from .._cli import build_app
+from .ingest import ingest
+
+app = build_app(
+    "orcid", ingest,
+    help=(
+        "Land ORCID identity records into lake.orcid.person (keyed on orcid_id). "
+        "Demand-driven: pass --orcids or --orcids-sql; the annual bulk file is "
+        "deliberately not used (see cdsci.lake.sources.orcid.ingest)."
+    ),
+)
+
+if __name__ == "__main__":
+    app()

--- a/src/cdsci/lake/sources/orcid/ingest.py
+++ b/src/cdsci/lake/sources/orcid/ingest.py
@@ -1,0 +1,240 @@
+"""ORCID → ``lake.orcid.person``: researcher-identity crosswalk (issue #56, EL only).
+
+**Deliberate deviation from this lake's "land raw whole" convention: the annual
+bulk Public Data File is not landed. The public API is, scoped to a caller-given
+set of ORCID iDs.** #56 anticipated this trade-off; here is what the real bytes
+said (checked 2026-08-11, figshare record ``10.23640/07243.30375589``, the 2025
+file):
+
+* The summaries archive alone is **46.33 GB compressed / 863,678 MB (~863 GB)
+  uncompressed**, plus eleven activities archives of 16–19 GB each — ~237 GB
+  compressed in total.
+* It is **XML, one file per record**, unpacked into ``summaries/<3-digit
+  checksum>/<iD>.xml``. There is no scannable bulk artifact at all: DuckDB reads
+  CSV/JSON/Parquet, not a tar of ~20 million tiny XML documents. Landing it
+  whole is not "a big download", it is a bespoke XML shredder for a registry
+  this lake has no reader for.
+* And the join it would serve does not exist yet: **no table in this lake
+  carries an ORCID iD today** (OpenAlex's authorship struct extracts
+  ``author.id``/``display_name`` and the institution ROR, not ``author.orcid``;
+  RePORTER carries PI names and RePORTER-internal ``pi_ids``). Landing 20M+
+  researcher records to join against zero rows is the definition of speculative.
+
+So the EL is demand-driven: hand it the iDs you actually have, it fetches those.
+The iD set comes from ``orcids=`` (a comma-separated list) or ``orcids_sql=``
+(any query against the attached lake returning one column of iDs — the
+"iDs referenced by existing sources" path #56 describes). It **refuses to guess**
+when given neither, rather than silently landing nothing. Once an ORCID-bearing
+column does land — adding ``"orcid":"VARCHAR"`` to OpenAlex's authorship struct
+is one line, but a separate change with a re-ingest attached — the default
+becomes a one-line ``orcids_sql``.
+
+The endpoint is ``expanded-search``, not ``/record``. Both are unauthenticated
+on ``pub.orcid.org``; ``/record`` returns ~254 KB of activities per researcher
+(one HTTP round trip each), while ``expanded-search`` answers ``orcid:(A OR B OR
+…)`` for **100 iDs in a single ~0.4 s request** and returns precisely the
+identity fields a crosswalk is for: iD, given/family/credit names, other names,
+emails, institution names. Verified on a real 100-iD batch: all 100 returned,
+``orcid-id`` unique, no padded strings, no nulls in given/family names. An iD
+that is unknown or withdrawn simply does not come back — the response is a hit
+list, not a per-iD result, so absence is silent by design.
+
+Because the registry is live and rolling (not a versioned release), the snapshot
+is tagged by retrieval date — the ``retractionwatch``/``ncbi_gene`` treatment.
+Fetched records are written to the raw layer as NDJSON before loading, so the
+medallion contract still holds: a re-curate needs no re-fetch.
+
+License: **CC0**. info.orcid.org/annual-data-files (confirmed 2026-08-11):
+"ORCID releases the Public Data File under a CC0 1.0 Public Domain Dedication as
+further described in our Privacy Policy", and the figshare record carries
+``license: CC0``. The same terms cover the public API's data (ORCID's Public
+Data File Use Policy adds community *norms* — cite ORCID, respect researcher
+deletions on refresh — not license conditions). Personal data: only fields the
+researcher chose to make public are returned, which is what makes the dedication
+possible; nothing here bypasses a record's privacy settings.
+
+Scope: EL only. Whether this ever reverse-ETLs to bioc-on-ice is the open
+question #56 raises and does not settle — deliberately left unanswered here, and
+publishing deferred per #63.
+
+On ``ref`` vs. its own schema (#56's other open question), the same grain
+argument #38 used for ``gene2pubmed``: ``ref.id_crosswalk``'s grain is one row
+per PMID, and a researcher is not a paper. Landing in ``lake.orcid`` keeps the
+rule simple — **a source's raw table lives in the source's schema; ``ref`` is
+the transform layer's namespace** (``models/ref/*.sql``). A researcher
+crosswalk, if ever wanted, belongs there as a model over this table. See
+``sources/ror/ingest.py`` for the same reasoning on the institution side.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Sequence
+from datetime import date
+from pathlib import Path
+
+import duckdb
+
+from ... import ops
+from ...config import Settings, get_settings
+from ...connect import LAKE, lake_connect, raw_dir, upsert
+from ...download import get_json
+from ...log import logger
+
+_RAW = "orcid"
+_log = logger.bind(ctx="orcid")
+
+# expanded-search's own JSON keys → (our column name, DuckDB type). Stated, not
+# sniffed: a renamed upstream key lands as an all-NULL column, which the
+# `orcid_id IS NOT NULL` guard in _select_sql turns into an empty load rather
+# than a silently half-populated table.
+COLUMNS: dict[str, tuple[str, str]] = {
+    "orcid-id": ("orcid_id", "VARCHAR"),
+    "given-names": ("given_names", "VARCHAR"),
+    "family-names": ("family_name", "VARCHAR"),
+    "credit-name": ("credit_name", "VARCHAR"),
+    "other-name": ("other_names", "VARCHAR[]"),
+    "email": ("emails", "VARCHAR[]"),
+    "institution-name": ("institution_names", "VARCHAR[]"),
+}
+
+
+def _sql_str(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _today_version() -> str:
+    """Snapshot label — the retrieval date (the registry is live, not released)."""
+    return date.today().isoformat()
+
+
+def _chunks(items: Sequence[str], size: int) -> Iterable[Sequence[str]]:
+    """``itertools.batched`` is 3.12+; this package supports 3.11."""
+    for start in range(0, len(items), size):
+        yield items[start : start + size]
+
+
+def fetch(
+    orcids: Sequence[str], version: str, settings: Settings | None = None
+) -> Path:
+    """Fetch ``orcids`` via batched ``expanded-search`` → one raw NDJSON file.
+
+    One request per :attr:`Settings.orcid_batch_size` iDs. The file is rewritten
+    each call (unlike a versioned bulk download, the registry moves under us and
+    the iD set is caller-chosen, so a same-day cache would be a trap).
+    """
+    s = settings or get_settings()
+    dest = raw_dir(_RAW, s) / f"{version}-person.ndjson"
+    found = 0
+    with open(dest, "w", encoding="utf-8") as fh:
+        for chunk in _chunks(orcids, s.orcid_batch_size):
+            payload = get_json(
+                f"{s.orcid_api_base}/expanded-search/",
+                params={"q": "orcid:(" + " OR ".join(chunk) + ")", "rows": str(len(chunk))},
+                headers={"Accept": "application/json"},
+            )
+            records = payload["expanded-result"] or []
+            for record in records:
+                fh.write(json.dumps(record) + "\n")
+            found += len(records)
+    _log.info("fetched {:,}/{:,} requested iDs → {}", found, len(orcids), dest.name)
+    return dest
+
+
+def _select_sql(path: Path, version: str, limit: int | None) -> str:
+    columns_sql = ", ".join(f"'{src}': '{typ}'" for src, (_, typ) in COLUMNS.items())
+    # Trim the scalar name columns (upstream is clean today; this is what keeps
+    # a padded name from silently breaking a join later). List columns land
+    # verbatim. `orcid_id` can never be NULL in a real response, and a NULL key
+    # would be a meaningless row here, so drop those outright.
+    projection = ",\n            ".join(
+        f'trim("{src}") AS {dst}' if typ == "VARCHAR" else f'"{src}" AS {dst}'
+        for src, (dst, typ) in COLUMNS.items()
+    )
+    limit_sql = f" LIMIT {int(limit)}" if limit else ""
+    return f"""
+        SELECT
+            {projection},
+            CAST({_sql_str(version)} AS VARCHAR) AS snapshot_version
+        FROM read_json(
+            {_sql_str(str(path))}, format = 'newline_delimited',
+            columns = {{{columns_sql}}}, auto_detect = false
+        )
+        WHERE nullif(trim("orcid-id"), '') IS NOT NULL
+        {limit_sql}
+    """
+
+
+def land(
+    con: duckdb.DuckDBPyConnection,
+    path: Path,
+    version: str,
+    *,
+    schema: str = "orcid",
+    limit: int | None = None,
+) -> int:
+    """MERGE-upsert a raw expanded-search NDJSON into ``lake.<schema>.person``."""
+    return upsert(
+        con, f"{LAKE}.{schema}.person", _select_sql(path, version, limit),
+        key="orcid_id", exclude_change_cols=["snapshot_version"],
+    )
+
+
+def resolve_orcids(
+    con: duckdb.DuckDBPyConnection,
+    *,
+    orcids: str | None,
+    orcids_sql: str | None,
+) -> list[str]:
+    """The iD set to fetch: an explicit list, or the first column of ``orcids_sql``.
+
+    Refuses to default. No table in this lake carries an ORCID iD yet (see the
+    module docstring), so an implicit "everything referenced" would quietly mean
+    "nothing" — the failure #56 warns against defaulting silently into.
+    """
+    if orcids:
+        ids = [o.strip() for o in orcids.split(",") if o.strip()]
+    elif orcids_sql:
+        ids = [row[0] for row in con.execute(orcids_sql).fetchall() if row[0]]
+    else:
+        raise ValueError(
+            "no ORCID iDs to fetch — pass orcids='0000-...,0000-...' or "
+            "orcids_sql='SELECT DISTINCT <col> FROM lake....'. This source is "
+            "demand-driven on purpose: the annual bulk file is ~863 GB of "
+            "per-record XML and nothing in this lake carries an ORCID iD yet "
+            "(see the module docstring)."
+        )
+    return sorted(set(ids))
+
+
+def ingest(
+    *,
+    orcids: str | None = None,
+    orcids_sql: str | None = None,
+    file: str | None = None,
+    version: str | None = None,
+    schema: str = "orcid",
+    limit: int | None = None,
+    settings: Settings | None = None,
+) -> dict:
+    """End-to-end: resolve iDs → batched API fetch (unless ``file``) → upsert → summary.
+
+    ``orcids`` is a comma-separated iD list; ``orcids_sql`` is any query against
+    the attached lake returning one column of iDs. ``file`` loads a raw
+    expanded-search NDJSON already on disk instead of calling the API.
+    """
+    s = settings or get_settings()
+    version = version or _today_version()
+    target = f"{LAKE}.{schema}.person"
+    con = lake_connect(s)
+    try:
+        path = (
+            Path(file) if file
+            else fetch(resolve_orcids(con, orcids=orcids, orcids_sql=orcids_sql), version, s)
+        )
+        with ops.run(con, source="orcid", target=target, version=version) as r:
+            r.rows = land(con, path, version, schema=schema, limit=limit)
+            _log.info("person <- {:,} rows ({})", r.rows, version)
+    finally:
+        con.close()
+    return r.summary()

--- a/src/cdsci/lake/sources/ror/__init__.py
+++ b/src/cdsci/lake/sources/ror/__init__.py
@@ -1,0 +1,17 @@
+"""ROR — the canonical, CC0 institution-identity authority (issue #57).
+
+One raw landing table, ``lake.ror.organization``, keyed on ``ror_id`` (the bare
+LUI). Joins ``lake.openalex.works_authorships`` via
+``split_part(institution_ror, '/', -1) = ror_id``. See ``ingest.py`` for the
+verified key, why the JSON dump is landed rather than the CSV subset, and why
+country is deliberately *not* derived.
+
+EL only: whether this ever reverse-ETLs to bioc-on-ice is the open question #57
+raises and does not settle; publishing is deferred per #63.
+
+License: CC0 (ror.readme.io/docs/data-dump).
+"""
+
+from .ingest import COLUMNS, check_keys, download_dump, ingest, land
+
+__all__ = ["COLUMNS", "check_keys", "download_dump", "ingest", "land"]

--- a/src/cdsci/lake/sources/ror/__main__.py
+++ b/src/cdsci/lake/sources/ror/__main__.py
@@ -1,0 +1,14 @@
+"""CLI: ``python -m cdsci.lake.sources.ror`` — land the ROR organization dump."""
+
+from __future__ import annotations
+
+from .._cli import build_app
+from .ingest import ingest
+
+app = build_app(
+    "ror", ingest,
+    help="Land the versioned ROR bulk dump into lake.ror.organization (keyed on ror_id).",
+)
+
+if __name__ == "__main__":
+    app()

--- a/src/cdsci/lake/sources/ror/ingest.py
+++ b/src/cdsci/lake/sources/ror/ingest.py
@@ -1,0 +1,240 @@
+"""ROR → ``lake.ror.organization``: the institution-identity authority (issue #57, EL only).
+
+RePORTER, OpenAlex and Reliance each name institutions their own way; ROR is the
+CC0 authority that reconciles them. This lake already carries the join key —
+``lake.openalex.works_authorships.institution_ror`` holds a full ROR URL — so
+this table turns an affiliation string into a resolvable organization today,
+with no new plumbing.
+
+Exactly the ``bioregistry`` shape (single versioned bulk file → MERGE-upsert),
+with one difference: ROR's dumps **carry their own version**. The Zenodo
+*concept* record (6347574) always resolves to the newest release, whose
+``metadata.version`` is the release tag (``v2.11``, 2026-08-03) — so the
+snapshot is tagged by the dump's version, the ``scp``/``bugsigdb`` treatment,
+not by pull date like the rolling sources.
+
+**JSON, not CSV.** The dump ships both; ROR states JSON is authoritative and the
+CSV a flattened subset (it drops ``relationships`` — the parent/child org
+hierarchy — and the per-name ``lang``/``types``). Landing the JSON keeps
+everything, and sidesteps a real hazard on the CSV path: **804 organization
+names contain a bare ``"``** (``Universitatea de Stat de Medicină și Farmacie
+"Nicolae Testemițanu"``), exactly the free-text-quote trap that costs the
+tab-delimited sources a ``quote=''``/``escape=''``. JSON quotes its own strings,
+so the question doesn't arise.
+
+Verified against the real v2.11 dump (135,710 records), not assumed:
+
+* **The key holds.** ``id`` is unique across all 135,710 records, and every one
+  is ``https://ror.org/<lui>``. Landed as the bare LUI (``04ttjf776``) per this
+  lake's id-column convention (#46: an ``<x>_id`` column holds the bioregistry
+  prefix's local identifier, not a URI). The full URL is
+  ``'https://ror.org/' || ror_id``, so it isn't landed; joining OpenAlex is
+  ``split_part(institution_ror, '/', -1) = ror_id``.
+* ``name`` is derived, and provably 1:1 — **every** record has exactly one name
+  typed ``ror_display``, so picking it is a fact, not a heuristic. The raw
+  ``names`` list lands verbatim beside it. Padding whitespace: 288 names carry
+  it (216 acronyms, 71 aliases, 1 label) — but **zero** ``ror_display`` names
+  do, so the ``trim()`` on ``name`` is defensive, not a fix for a live bug the
+  way Reactome's was. Kept anyway: it costs nothing and the join column is the
+  one place padding silently breaks things.
+* **Country is deliberately not derived.** 131 records have more than one
+  location (up to 5), so a ``locations[1]`` country would silently pick one.
+  ``locations`` lands whole and nested; unnest it if you need every site.
+* ``established`` is a year, NULL for 26,434 records; no ``-``/``\\N`` sentinel
+  appears anywhere in the dump (it is JSON — absence is ``null``), so there is
+  nothing to declare a ``nullstr`` for.
+* ``status`` is ``active`` (132,706) / ``inactive`` (1,595) / ``withdrawn``
+  (1,409). All three land: a withdrawn ROR id still needs to resolve for
+  historical affiliation data.
+* Nested ``LIST<STRUCT>`` columns round-trip through DuckLake/Parquet and MERGE
+  idempotently (verified end-to-end on all 135,710 rows).
+
+Column drift: the type spec below is stated, never sniffed (``auto_detect=false``).
+But JSON columns are *name*-addressed, so drift can't shift values one to the
+left the way it can in a headerless TSV — it fails quietly instead, as a column
+that silently goes all-NULL. :func:`check_keys` restores the loud failure by
+sweeping every record's top-level key set against the spec before loading
+(0.7 s on the real file).
+
+License: **CC0**. ror.readme.io/docs/data-dump (confirmed 2026-08-11): "All ROR
+IDs and metadata in the data dump are provided under the Creative Commons CC0
+1.0 Universal Public Domain Dedication." The Zenodo record itself carries
+``license: cc-zero``.
+
+Scope: EL only. Whether this ever reverse-ETLs to bioc-on-ice is the open
+question #57 itself raises and does not settle — deliberately left unanswered
+here, and publishing deferred per #63.
+
+On ``ref`` vs. its own schema (#57's other open question), the same grain
+argument #38 used for ``gene2pubmed``: ``ref.id_crosswalk``'s grain is one row
+per PMID, and an organization is not a paper — it cannot go there without
+breaking the grain. ``ref.bioregistry`` is the tempting counterexample, but it
+is a *registry of this lake's own naming convention*, not an upstream entity
+with a release cadence. Landing in ``lake.ror`` keeps the rule simple: **a
+source's raw table lives in the source's schema; ``ref`` is the transform
+layer's namespace** (``models/ref/*.sql``). If an institution crosswalk is ever
+wanted, it belongs there as a model over this table — a decision that stays
+cheap precisely because the raw landing didn't presume it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import duckdb
+
+from ... import ops
+from ...config import Settings, get_settings
+from ...connect import LAKE, lake_connect, raw_dir, upsert
+from ...download import download, get_json, unzip
+from ...log import logger
+
+_RAW = "ror"
+_log = logger.bind(ctx="ror")
+
+_GEONAMES = (
+    "STRUCT(continent_code VARCHAR, continent_name VARCHAR, country_code VARCHAR, "
+    "country_name VARCHAR, country_subdivision_code VARCHAR, "
+    "country_subdivision_name VARCHAR, lat DOUBLE, lng DOUBLE, name VARCHAR)"
+)
+_ADMIN_ENTRY = 'STRUCT("date" VARCHAR, schema_version VARCHAR)'
+
+# The dump's own top-level keys → the DuckDB type each lands as, stated rather
+# than sniffed. `all` and `type` and `date` are quoted: they are DuckDB keywords.
+COLUMNS: dict[str, str] = {
+    "id": "VARCHAR",
+    "names": "STRUCT(value VARCHAR, types VARCHAR[], lang VARCHAR)[]",
+    "status": "VARCHAR",
+    "types": "VARCHAR[]",
+    "established": "BIGINT",
+    "domains": "VARCHAR[]",
+    "links": 'STRUCT("type" VARCHAR, value VARCHAR)[]',
+    "external_ids": 'STRUCT("type" VARCHAR, "all" VARCHAR[], preferred VARCHAR)[]',
+    "relationships": 'STRUCT("type" VARCHAR, label VARCHAR, id VARCHAR)[]',
+    "locations": f"STRUCT(geonames_id BIGINT, geonames_details {_GEONAMES})[]",
+    "admin": f"STRUCT(created {_ADMIN_ENTRY}, last_modified {_ADMIN_ENTRY})",
+}
+
+# Everything except `id` (→ ror_id) and the derived `name` lands under its own
+# upstream key.
+_VERBATIM = tuple(k for k in COLUMNS if k != "id")
+
+
+def _sql_str(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _version_from_name(path: Path) -> str:
+    """``v2.11-2026-08-03-ror-data.json`` → ``v2.11`` (the release's own tag)."""
+    match = re.match(r"(v[\d.]+?)-\d{4}-\d{2}-\d{2}-", path.name)
+    if not match:
+        raise ValueError(
+            f"cannot read a ROR release version out of {path.name!r} — pass version=..."
+        )
+    return match.group(1)
+
+
+def download_dump(settings: Settings | None = None) -> tuple[Path, str]:
+    """Download + unzip the newest ROR dump; return ``(json path, version)``.
+
+    The Zenodo *concept* record resolves to the latest release, so there is no
+    version to pin in config — the release names itself.
+    """
+    s = settings or get_settings()
+    record = get_json(f"https://zenodo.org/api/records/{s.ror_zenodo_concept_record}")
+    version = record["metadata"]["version"]
+    files = record["files"]
+    if len(files) != 1:
+        raise ValueError(f"expected one ROR dump archive on Zenodo, got {len(files)}")
+    archive = download(files[0]["links"]["self"], raw_dir(_RAW, s) / files[0]["key"])
+    members = unzip(archive, raw_dir(_RAW, s) / version)
+    jsons = [p for p in members if p.suffix == ".json"]
+    if len(jsons) != 1:
+        raise ValueError(f"expected one .json in {archive.name}, got {[p.name for p in jsons]}")
+    return jsons[0], version
+
+
+def check_keys(con: duckdb.DuckDBPyConnection, path: Path) -> None:
+    """Fail loudly if the dump's top-level keys have drifted from :data:`COLUMNS`.
+
+    A JSON column spec is name-addressed, so a renamed/dropped upstream key would
+    otherwise land as a silently all-NULL column rather than an error. One sweep
+    of every record's key set (0.7 s over the real 305 MB dump) buys the loud
+    failure a headerless TSV gets from a positional spec.
+    """
+    found = {
+        k for (k,) in con.execute(
+            f"SELECT DISTINCT unnest(json_keys(json)) "
+            f"FROM read_json_objects({_sql_str(str(path))}, format = 'array')"
+        ).fetchall()
+    }
+    if found != set(COLUMNS):
+        raise ValueError(
+            f"ROR dump keys drifted: +{sorted(found - set(COLUMNS))} "
+            f"-{sorted(set(COLUMNS) - found)} — update COLUMNS before landing"
+        )
+
+
+def _select_sql(path: Path, version: str, limit: int | None) -> str:
+    columns_sql = ", ".join(f"'{k}': '{t}'" for k, t in COLUMNS.items())
+    verbatim = ",\n            ".join(_VERBATIM)
+    limit_sql = f" LIMIT {int(limit)}" if limit else ""
+    # `name` is the one derived column: every record has exactly one ror_display
+    # name (verified across all 135,710), trimmed because 288 arrive padded.
+    return f"""
+        SELECT
+            split_part(id, '/', -1) AS ror_id,
+            trim(list_filter(names, n -> list_contains(n.types, 'ror_display'))[1].value)
+                AS name,
+            {verbatim},
+            CAST({_sql_str(version)} AS VARCHAR) AS snapshot_version
+        FROM read_json(
+            {_sql_str(str(path))}, format = 'array',
+            columns = {{{columns_sql}}}, auto_detect = false
+        )
+        {limit_sql}
+    """
+
+
+def land(
+    con: duckdb.DuckDBPyConnection,
+    path: Path,
+    version: str,
+    *,
+    schema: str = "ror",
+    limit: int | None = None,
+) -> int:
+    """MERGE-upsert one ROR dump into ``lake.<schema>.organization`` on ``ror_id``."""
+    check_keys(con, path)
+    return upsert(
+        con, f"{LAKE}.{schema}.organization", _select_sql(path, version, limit),
+        key="ror_id", exclude_change_cols=["snapshot_version"],
+    )
+
+
+def ingest(
+    *,
+    file: str | None = None,
+    version: str | None = None,
+    schema: str = "ror",
+    limit: int | None = None,
+    settings: Settings | None = None,
+) -> dict:
+    """End-to-end: fetch the newest dump (unless ``file``) → MERGE-upsert → summary."""
+    s = settings or get_settings()
+    if file:
+        path = Path(file)
+        version = version or _version_from_name(path)
+    else:
+        path, dump_version = download_dump(s)
+        version = version or dump_version
+    target = f"{LAKE}.{schema}.organization"
+    con = lake_connect(s)
+    try:
+        with ops.run(con, source="ror", target=target, version=version) as r:
+            r.rows = land(con, path, version, schema=schema, limit=limit)
+            _log.info("organization <- {:,} rows ({})", r.rows, version)
+    finally:
+        con.close()
+    return r.summary()

--- a/tests/fixtures/orcid_expanded_search_sample.ndjson
+++ b/tests/fixtures/orcid_expanded_search_sample.ndjson
@@ -1,0 +1,5 @@
+{"orcid-id": "0000-0003-0307-290X", "given-names": "Erica", "family-names": "Davis", "credit-name": "Erica Davis", "other-name": ["Erica L Davis"], "email": [], "institution-name": ["Emory University School of Public Health", "University of Pennsylvania Perelman School of Medicine"]}
+{"orcid-id": "0000-0003-1723-4551", "given-names": "Kate", "family-names": "Davis", "credit-name": null, "other-name": [], "email": [], "institution-name": ["California University of PA", "Clinical Practice Advisory Board for Student Teaching", "Robert Morris University", "Washington School District"]}
+{"orcid-id": "0000-0002-0503-3894", "given-names": "Dave", "family-names": "Davis", "credit-name": null, "other-name": [], "email": [], "institution-name": ["Assured Environmental"]}
+{"orcid-id": "0000-0001-9363-7366", "given-names": "Walter", "family-names": "Davis", "credit-name": null, "other-name": [], "email": [], "institution-name": ["Kent State University"]}
+{"orcid-id": "0000-0003-4595-8047", "given-names": "Lajuan", "family-names": "Davis", "credit-name": null, "other-name": [], "email": [], "institution-name": ["The University of Tennessee at Martin"]}

--- a/tests/fixtures/ror_sample.json
+++ b/tests/fixtures/ror_sample.json
@@ -1,0 +1,561 @@
+[
+ {
+  "locations": [
+   {
+    "geonames_id": 2158177,
+    "geonames_details": {
+     "continent_code": "OC",
+     "continent_name": "Oceania",
+     "country_code": "AU",
+     "country_name": "Australia",
+     "country_subdivision_code": "VIC",
+     "country_subdivision_name": "Victoria",
+     "lat": -37.814,
+     "lng": 144.96332,
+     "name": "Melbourne"
+    }
+   }
+  ],
+  "established": 1887,
+  "external_ids": [
+   {
+    "type": "fundref",
+    "all": [
+     "501100001780",
+     "100008690",
+     "100010552"
+    ],
+    "preferred": "501100001780"
+   },
+   {
+    "type": "grid",
+    "all": [
+     "grid.1017.7"
+    ],
+    "preferred": "grid.1017.7"
+   },
+   {
+    "type": "isni",
+    "all": [
+     "0000 0001 2163 3550"
+    ],
+    "preferred": null
+   },
+   {
+    "type": "wikidata",
+    "all": [
+     "Q1057890"
+    ],
+    "preferred": null
+   }
+  ],
+  "id": "https://ror.org/04ttjf776",
+  "domains": [],
+  "links": [
+   {
+    "type": "website",
+    "value": "https://www.rmit.edu.au/"
+   },
+   {
+    "type": "wikipedia",
+    "value": "http://en.wikipedia.org/wiki/RMIT_University"
+   }
+  ],
+  "names": [
+   {
+    "value": "RMIT",
+    "types": [
+     "acronym"
+    ],
+    "lang": null
+   },
+   {
+    "value": "RMIT University",
+    "types": [
+     "ror_display",
+     "label"
+    ],
+    "lang": "en"
+   },
+   {
+    "value": "Royal Melbourne Institute of Technology University",
+    "types": [
+     "alias"
+    ],
+    "lang": "en"
+   }
+  ],
+  "relationships": [
+   {
+    "type": "child",
+    "label": "ARC Centre of Excellence for Automated Decision-Making and Society",
+    "id": "https://ror.org/039p7nx39"
+   },
+   {
+    "type": "child",
+    "label": "RMIT Europe",
+    "id": "https://ror.org/03m3ca021"
+   },
+   {
+    "type": "child",
+    "label": "RMIT Vietnam",
+    "id": "https://ror.org/004axh929"
+   },
+   {
+    "type": "related",
+    "label": "Austin Hospital",
+    "id": "https://ror.org/010mv7n52"
+   }
+  ],
+  "status": "active",
+  "types": [
+   "education",
+   "funder"
+  ],
+  "admin": {
+   "created": {
+    "date": "2018-11-14",
+    "schema_version": "1.0"
+   },
+   "last_modified": {
+    "date": "2024-12-11",
+    "schema_version": "2.1"
+   }
+  }
+ },
+ {
+  "locations": [
+   {
+    "geonames_id": 2524170,
+    "geonames_details": {
+     "continent_code": "EU",
+     "continent_name": "Europe",
+     "country_code": "IT",
+     "country_name": "Italy",
+     "country_subdivision_code": "82",
+     "country_subdivision_name": "Sicily",
+     "lat": 38.19394,
+     "lng": 15.55256,
+     "name": "Messina"
+    }
+   }
+  ],
+  "established": 1967,
+  "external_ids": [
+   {
+    "type": "grid",
+    "all": [
+     "grid.412507.5"
+    ],
+    "preferred": "grid.412507.5"
+   },
+   {
+    "type": "isni",
+    "all": [
+     "0000 0004 1773 5724"
+    ],
+    "preferred": null
+   }
+  ],
+  "id": "https://ror.org/03tf96d34",
+  "domains": [],
+  "links": [
+   {
+    "type": "website",
+    "value": "http://www.polime.it/"
+   }
+  ],
+  "names": [
+   {
+    "value": "Azienda Ospedaliera Universitaria Policlinico \"G. Martino\"",
+    "types": [
+     "ror_display",
+     "label"
+    ],
+    "lang": "it"
+   }
+  ],
+  "relationships": [],
+  "status": "active",
+  "types": [
+   "healthcare"
+  ],
+  "admin": {
+   "created": {
+    "date": "2018-11-14",
+    "schema_version": "1.0"
+   },
+   "last_modified": {
+    "date": "2024-12-11",
+    "schema_version": "2.1"
+   }
+  }
+ },
+ {
+  "locations": [
+   {
+    "geonames_id": 2800866,
+    "geonames_details": {
+     "continent_code": "EU",
+     "continent_name": "Europe",
+     "country_code": "BE",
+     "country_name": "Belgium",
+     "country_subdivision_code": "BRU",
+     "country_subdivision_name": "Brussels Capital",
+     "lat": 50.85045,
+     "lng": 4.34878,
+     "name": "Brussels"
+    }
+   }
+  ],
+  "established": 1991,
+  "external_ids": [
+   {
+    "type": "grid",
+    "all": [
+     "grid.6228.e"
+    ],
+    "preferred": "grid.6228.e"
+   }
+  ],
+  "id": "https://ror.org/05re2b915",
+  "domains": [],
+  "links": [
+   {
+    "type": "website",
+    "value": "http://ertico.com/"
+   }
+  ],
+  "names": [
+   {
+    "value": "ERTICO ",
+    "types": [
+     "acronym"
+    ],
+    "lang": null
+   },
+   {
+    "value": "European Road Transport Telematics Implementation Co-Ordination",
+    "types": [
+     "ror_display",
+     "label"
+    ],
+    "lang": "en"
+   }
+  ],
+  "relationships": [],
+  "status": "active",
+  "types": [
+   "other"
+  ],
+  "admin": {
+   "created": {
+    "date": "2018-11-14",
+    "schema_version": "1.0"
+   },
+   "last_modified": {
+    "date": "2024-12-11",
+    "schema_version": "2.1"
+   }
+  }
+ },
+ {
+  "admin": {
+   "created": {
+    "date": "2024-05-27",
+    "schema_version": "2.0"
+   },
+   "last_modified": {
+    "date": "2024-12-11",
+    "schema_version": "2.1"
+   }
+  },
+  "domains": [],
+  "established": 1975,
+  "external_ids": [
+   {
+    "all": [
+     "Q95580135"
+    ],
+    "preferred": "Q95580135",
+    "type": "wikidata"
+   }
+  ],
+  "id": "https://ror.org/05qhvy459",
+  "links": [
+   {
+    "type": "website",
+    "value": "https://sprakbanken.se"
+   },
+   {
+    "type": "wikipedia",
+    "value": "https://sv.wikipedia.org/wiki/Nationella_spr%C3%A5kbanken"
+   }
+  ],
+  "locations": [
+   {
+    "geonames_details": {
+     "continent_code": "EU",
+     "continent_name": "Europe",
+     "country_code": "SE",
+     "country_name": "Sweden",
+     "country_subdivision_code": "C",
+     "country_subdivision_name": "Uppsala",
+     "lat": 59.85882,
+     "lng": 17.63889,
+     "name": "Uppsala"
+    },
+    "geonames_id": 2666199
+   },
+   {
+    "geonames_details": {
+     "continent_code": "EU",
+     "continent_name": "Europe",
+     "country_code": "SE",
+     "country_name": "Sweden",
+     "country_subdivision_code": "AB",
+     "country_subdivision_name": "Stockholm",
+     "lat": 59.32938,
+     "lng": 18.06871,
+     "name": "Stockholm"
+    },
+    "geonames_id": 2673730
+   },
+   {
+    "geonames_details": {
+     "continent_code": "EU",
+     "continent_name": "Europe",
+     "country_code": "SE",
+     "country_name": "Sweden",
+     "country_subdivision_code": "O",
+     "country_subdivision_name": "Västra Götaland",
+     "lat": 57.70716,
+     "lng": 11.96679,
+     "name": "Gothenburg"
+    },
+    "geonames_id": 2711537
+   }
+  ],
+  "names": [
+   {
+    "lang": "sv",
+    "types": [
+     "label",
+     "ror_display"
+    ],
+    "value": "Språkbanken"
+   }
+  ],
+  "relationships": [
+   {
+    "label": "Språkbanken Tal",
+    "type": "child",
+    "id": "https://ror.org/05kbck686"
+   },
+   {
+    "label": "Språkbanken Text",
+    "type": "child",
+    "id": "https://ror.org/03xfh2n14"
+   },
+   {
+    "label": "Språkbanken Sam",
+    "type": "child",
+    "id": "https://ror.org/01mqjeb88"
+   }
+  ],
+  "status": "active",
+  "types": [
+   "archive"
+  ]
+ },
+ {
+  "locations": [
+   {
+    "geonames_id": 1816670,
+    "geonames_details": {
+     "continent_code": "AS",
+     "continent_name": "Asia",
+     "country_code": "CN",
+     "country_name": "China",
+     "country_subdivision_code": "BJ",
+     "country_subdivision_name": "Beijing",
+     "lat": 39.9075,
+     "lng": 116.39723,
+     "name": "Beijing"
+    }
+   }
+  ],
+  "established": 2011,
+  "external_ids": [
+   {
+    "type": "grid",
+    "all": [
+     "grid.511812.e"
+    ],
+    "preferred": "grid.511812.e"
+   }
+  ],
+  "id": "https://ror.org/058mseb02",
+  "domains": [],
+  "links": [
+   {
+    "type": "website",
+    "value": "https://en.cfsa.net.cn/"
+   }
+  ],
+  "names": [
+   {
+    "value": "CFSA",
+    "types": [
+     "acronym"
+    ],
+    "lang": null
+   },
+   {
+    "value": "China National Centre for Food Safety Risk Assessment",
+    "types": [
+     "ror_display",
+     "label"
+    ],
+    "lang": "en"
+   }
+  ],
+  "relationships": [
+   {
+    "label": "China National Center for Food Safety Risk Assessment",
+    "type": "successor",
+    "id": "https://ror.org/03kcjz738"
+   }
+  ],
+  "status": "withdrawn",
+  "types": [
+   "government"
+  ],
+  "admin": {
+   "created": {
+    "date": "2021-09-23",
+    "schema_version": "1.0"
+   },
+   "last_modified": {
+    "date": "2024-12-11",
+    "schema_version": "2.1"
+   }
+  }
+ },
+ {
+  "locations": [
+   {
+    "geonames_id": 2155472,
+    "geonames_details": {
+     "continent_code": "OC",
+     "continent_name": "Oceania",
+     "country_code": "AU",
+     "country_name": "Australia",
+     "country_subdivision_code": "NSW",
+     "country_subdivision_name": "New South Wales",
+     "lat": -32.92953,
+     "lng": 151.7801,
+     "name": "Newcastle"
+    }
+   }
+  ],
+  "established": null,
+  "external_ids": [
+   {
+    "type": "fundref",
+    "all": [
+     "100010635"
+    ],
+    "preferred": null
+   },
+   {
+    "type": "grid",
+    "all": [
+     "grid.3006.5"
+    ],
+    "preferred": "grid.3006.5"
+   },
+   {
+    "type": "isni",
+    "all": [
+     "0000 0004 0438 2042"
+    ],
+    "preferred": null
+   }
+  ],
+  "id": "https://ror.org/050b31k83",
+  "domains": [],
+  "links": [
+   {
+    "type": "website",
+    "value": "http://www.hnehealth.nsw.gov.au/Pages/home.aspx"
+   }
+  ],
+  "names": [
+   {
+    "value": "HNE Health",
+    "types": [
+     "alias"
+    ],
+    "lang": "en"
+   },
+   {
+    "value": "Hunter New England Health",
+    "types": [
+     "alias"
+    ],
+    "lang": "en"
+   },
+   {
+    "value": "Hunter New England Local Health District",
+    "types": [
+     "ror_display",
+     "label"
+    ],
+    "lang": "en"
+   }
+  ],
+  "relationships": [
+   {
+    "type": "child",
+    "label": "Belmont Hospital",
+    "id": "https://ror.org/045tkmf79"
+   },
+   {
+    "type": "child",
+    "label": "Hunter Genetics",
+    "id": "https://ror.org/00w1xt505"
+   },
+   {
+    "type": "child",
+    "label": "John Hunter Children's Hospital",
+    "id": "https://ror.org/048sjbt91"
+   },
+   {
+    "type": "child",
+    "label": "John Hunter Hospital",
+    "id": "https://ror.org/0187t0j49"
+   },
+   {
+    "type": "child",
+    "label": "Tamworth Hospital",
+    "id": "https://ror.org/02f53md90"
+   }
+  ],
+  "status": "active",
+  "types": [
+   "healthcare",
+   "funder"
+  ],
+  "admin": {
+   "created": {
+    "date": "2018-11-14",
+    "schema_version": "1.0"
+   },
+   "last_modified": {
+    "date": "2024-12-11",
+    "schema_version": "2.1"
+   }
+  }
+ }
+]

--- a/tests/test_orcid.py
+++ b/tests/test_orcid.py
@@ -1,0 +1,121 @@
+"""Offline tests for the ORCID source (issue #56, EL only).
+
+The fixture is five *real* ``expanded-search`` results (raw NDJSON, exactly what
+:func:`cdsci.lake.sources.orcid.fetch` writes to the raw layer), including an iD
+ending in ``X``, a record with alternate names, and one with several institution
+affiliations. No network — except the ``RUN_INTEGRATION`` test, which calls the
+real public API.
+
+The load being demand-driven rather than bulk is the deliberate deviation this
+source is built on; ``test_orcid_refuses_to_guess_an_id_set`` is the guard that
+keeps it explicit instead of silently landing nothing.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from cdsci.lake import Settings, lake_connect, ops, table_exists
+from cdsci.lake.sources import orcid
+
+FIXTURES = Path(__file__).parent / "fixtures"
+SAMPLE = FIXTURES / "orcid_expanded_search_sample.ndjson"
+VERSION = "test-2026-08-11"
+# Real, public, long-lived iDs (ORCID's own demo record + this lake's author).
+REAL_IDS = "0000-0002-1825-0097,0000-0002-8991-6458"
+
+
+@pytest.fixture
+def lake_settings(tmp_path: Path) -> Settings:
+    return Settings(storage_base_uri=f"file://{tmp_path}")
+
+
+def test_orcid_land(lake_settings: Settings):
+    con = lake_connect(lake_settings)
+    try:
+        ops.register_sources(con, writer="cdsci", sources=ops.SOURCES)
+
+        assert orcid.land(con, SAMPLE, VERSION) == 5
+        assert table_exists(con, "person")
+
+        # An iD's check digit can be X — it is text, never numeric.
+        assert con.execute("""
+            SELECT given_names, family_name, other_names
+            FROM lake.orcid.person WHERE orcid_id = '0000-0003-0307-290X'
+        """).fetchone() == ("Erica", "Davis", ["Erica L Davis"])
+
+        # Affiliations are a list, not a single institution.
+        assert con.execute("""
+            SELECT len(institution_names) FROM lake.orcid.person
+            WHERE orcid_id = '0000-0003-1723-4551'
+        """).fetchone()[0] == 4
+
+        # Empty upstream lists stay empty lists, not NULL.
+        assert con.execute("""
+            SELECT other_names FROM lake.orcid.person
+            WHERE orcid_id = '0000-0002-0503-3894'
+        """).fetchone()[0] == []
+
+        lic = con.execute(
+            "SELECT license FROM ops.lake_ops.source WHERE name = 'orcid'"
+        ).fetchone()[0]
+        assert lic == "cc0"
+
+        before = con.execute("SELECT max(snapshot_id) FROM lake.snapshots()").fetchone()[0]
+        orcid.land(con, SAMPLE, VERSION)
+        after = con.execute("SELECT max(snapshot_id) FROM lake.snapshots()").fetchone()[0]
+        assert before == after
+    finally:
+        con.close()
+
+
+def test_orcid_ingest_end_to_end(lake_settings: Settings):
+    """``ingest(file=...)`` brackets in ops.run, no API call."""
+    summary = orcid.ingest(file=str(SAMPLE), version=VERSION, settings=lake_settings)
+    assert summary["rows"] == 5
+    assert summary["status"] == "success"
+
+
+def test_orcid_refuses_to_guess_an_id_set(lake_settings: Settings):
+    """No iDs given → a loud error, never an empty silent load (#56)."""
+    with pytest.raises(ValueError, match="no ORCID iDs to fetch"):
+        orcid.ingest(settings=lake_settings)
+
+
+def test_orcid_resolve_orcids(lake_settings: Settings):
+    """Both id sources: an explicit list, and a query over the attached lake."""
+    con = lake_connect(lake_settings)
+    try:
+        assert orcid.resolve_orcids(
+            con, orcids=" 0000-0002-1825-0097 , 0000-0002-8991-6458 ,", orcids_sql=None
+        ) == ["0000-0002-1825-0097", "0000-0002-8991-6458"]
+        # The "iDs referenced by an existing source" path: any lake query works.
+        con.execute("CREATE TEMP TABLE authors AS SELECT * FROM (VALUES "
+                    "('0000-0002-1825-0097'), ('0000-0002-1825-0097'), (NULL)) t(orcid_id)")
+        assert orcid.resolve_orcids(
+            con, orcids=None, orcids_sql="SELECT orcid_id FROM authors"
+        ) == ["0000-0002-1825-0097"]
+    finally:
+        con.close()
+
+
+@pytest.mark.skipif(not os.getenv("RUN_INTEGRATION"), reason="calls the real ORCID API")
+def test_orcid_real_api(lake_settings: Settings):
+    """Real bytes: batch-fetch two public iDs and land them."""
+    summary = orcid.ingest(orcids=REAL_IDS, settings=lake_settings)
+    assert summary["status"] == "success"
+    con = lake_connect(lake_settings, read_only=True)
+    try:
+        rows, keys = con.execute(
+            "SELECT count(*), count(DISTINCT orcid_id) FROM lake.orcid.person"
+        ).fetchone()
+        assert rows == keys == 2
+        assert con.execute("""
+            SELECT family_name FROM lake.orcid.person
+            WHERE orcid_id = '0000-0002-1825-0097'
+        """).fetchone()[0] == "Carberry"
+    finally:
+        con.close()

--- a/tests/test_ror.py
+++ b/tests/test_ror.py
@@ -1,0 +1,148 @@
+"""Offline tests for the ROR source (issue #57, EL only).
+
+The fixture is six *real* records sliced out of the v2.11 dump, each chosen for
+a property the load has to get right: a bare ``"`` in an organization name, an
+alternate name with padding whitespace, three locations on one record, a
+withdrawn status, and a NULL ``established``. No network — except the
+``RUN_INTEGRATION`` test, which fetches the real 135k-record dump.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from cdsci.lake import Settings, lake_connect, ops, table_exists
+from cdsci.lake.sources import ror
+from cdsci.lake.sources.ror.ingest import _version_from_name
+
+FIXTURES = Path(__file__).parent / "fixtures"
+SAMPLE = FIXTURES / "ror_sample.json"
+VERSION = "v2.11"
+
+
+@pytest.fixture
+def lake_settings(tmp_path: Path) -> Settings:
+    return Settings(storage_base_uri=f"file://{tmp_path}")
+
+
+def test_ror_land(lake_settings: Settings):
+    con = lake_connect(lake_settings)
+    try:
+        # land() is called directly (not via ops.run), so register explicitly.
+        ops.register_sources(con, writer="cdsci", sources=ops.SOURCES)
+
+        assert ror.land(con, SAMPLE, VERSION) == 6
+        assert table_exists(con, "organization")
+
+        # ror_id is the bare LUI, not the URI (#46's id-column convention), and
+        # `name` is the single ror_display name.
+        assert con.execute("""
+            SELECT ror_id, name, status, established
+            FROM lake.ror.organization WHERE ror_id = '04ttjf776'
+        """).fetchone() == ("04ttjf776", "RMIT University", "active", 1887)
+
+        # 804 real names carry a bare double quote — JSON quotes its own strings,
+        # so nothing mangles them (the reason the CSV subset isn't landed).
+        assert con.execute("""
+            SELECT name FROM lake.ror.organization WHERE ror_id = '03tf96d34'
+        """).fetchone()[0] == 'Azienda Ospedaliera Universitaria Policlinico "G. Martino"'
+
+        # The raw names list lands verbatim — padding included. (Trimming happens
+        # on the derived `name` only; no ror_display name is padded upstream.)
+        assert con.execute("""
+            SELECT list_filter(names, n -> list_contains(n.types, 'acronym'))[1].value
+            FROM lake.ror.organization WHERE ror_id = '05re2b915'
+        """).fetchone()[0] == "ERTICO "
+
+        # Country is deliberately not derived: this record has three locations.
+        assert con.execute("""
+            SELECT len(locations) FROM lake.ror.organization WHERE ror_id = '05qhvy459'
+        """).fetchone()[0] == 3
+
+        # Withdrawn records still land — a retired ROR id must resolve for
+        # historical affiliation data.
+        assert con.execute("""
+            SELECT status FROM lake.ror.organization WHERE ror_id = '058mseb02'
+        """).fetchone()[0] == "withdrawn"
+
+        # established is genuinely absent for 26,434 records; NULL, not 0.
+        assert con.execute("""
+            SELECT established FROM lake.ror.organization WHERE ror_id = '050b31k83'
+        """).fetchone()[0] is None
+
+        # Nested LIST<STRUCT> round-trips through DuckLake.
+        assert con.execute("""
+            SELECT list_filter(external_ids, e -> e."type" = 'grid')[1].preferred
+            FROM lake.ror.organization WHERE ror_id = '04ttjf776'
+        """).fetchone()[0] == "grid.1017.7"
+        assert con.execute("""
+            SELECT count(*) FROM (
+                SELECT unnest(relationships) r FROM lake.ror.organization
+                WHERE ror_id = '04ttjf776'
+            ) WHERE r."type" = 'child'
+        """).fetchone()[0] == 3
+
+        lic = con.execute(
+            "SELECT license FROM ops.lake_ops.source WHERE name = 'ror'"
+        ).fetchone()[0]
+        assert lic == "cc0"
+
+        # Idempotent re-run adds no snapshot (nested columns compare cleanly).
+        before = con.execute("SELECT max(snapshot_id) FROM lake.snapshots()").fetchone()[0]
+        ror.land(con, SAMPLE, VERSION)
+        after = con.execute("SELECT max(snapshot_id) FROM lake.snapshots()").fetchone()[0]
+        assert before == after
+    finally:
+        con.close()
+
+
+def test_ror_ingest_end_to_end(lake_settings: Settings):
+    """``ingest(file=...)`` brackets in ops.run, no network."""
+    summary = ror.ingest(file=str(SAMPLE), version=VERSION, settings=lake_settings)
+    assert summary["rows"] == 6
+    assert summary["status"] == "success"
+    assert summary["version"] == VERSION
+
+
+def test_ror_version_comes_from_the_dump():
+    """A ROR release names itself — the snapshot is not tagged by pull date."""
+    assert _version_from_name(Path("v2.11-2026-08-03-ror-data.json")) == "v2.11"
+    with pytest.raises(ValueError, match="release version"):
+        _version_from_name(Path("ror_sample.json"))
+
+
+def test_ror_key_drift_fails_loudly(lake_settings: Settings, tmp_path: Path):
+    """A renamed upstream key would otherwise land as a silent all-NULL column."""
+    records = json.loads(SAMPLE.read_text())
+    for record in records:
+        record["organisation_names"] = record.pop("names")
+    drifted = tmp_path / "drifted.json"
+    drifted.write_text(json.dumps(records))
+    con = lake_connect(lake_settings)
+    try:
+        with pytest.raises(ValueError, match="keys drifted"):
+            ror.land(con, drifted, VERSION)
+    finally:
+        con.close()
+
+
+@pytest.mark.skipif(not os.getenv("RUN_INTEGRATION"), reason="downloads the real ROR dump")
+def test_ror_real_dump(lake_settings: Settings):
+    """Real bytes: the whole current dump, checking ror_id really is unique."""
+    summary = ror.ingest(settings=lake_settings)
+    assert summary["status"] == "success"
+    con = lake_connect(lake_settings, read_only=True)
+    try:
+        rows, keys, named = con.execute(
+            "SELECT count(*), count(DISTINCT ror_id), count(name) "
+            "FROM lake.ror.organization"
+        ).fetchone()
+        assert rows == keys, "ror_id is not unique"
+        assert named == rows, "every record has exactly one ror_display name"
+        assert rows > 130_000
+    finally:
+        con.close()


### PR DESCRIPTION
Two sibling identity authorities, both CC0, both **EL only**: ROR for institutions, ORCID for researchers.

Part of #56, Part of #57 — deliberately **not** "Closes".

## Scope: no reverse-ETL, no publish

Neither issue settles whether these feed a reverse-ETL target, and this PR does not settle it either. Nothing here publishes: no `transform publish`, no bioc-on-ice table, no `models/` changes. Standing direction after #63 is build-in-cdsci-lake-first.

Both issues' *other* open question — `ref` schema vs. own schema — is answered in the module docstrings with the same grain argument #38 used for `gene2pubmed`: `ref.id_crosswalk`'s grain is one row per PMID, and neither an organization nor a researcher is a paper. The rule the docstrings land on: **a source's raw table lives in the source's schema; `ref` is the transform layer's namespace** (`models/ref/*.sql`). So `lake.ror.organization` and `lake.orcid.person`. If a crosswalk is ever wanted it belongs in `ref` as a *model over* these tables — which stays cheap precisely because the landing didn't presume it. (`ref.bioregistry` is the counterexample, and it's a registry of this lake's own naming convention, not an upstream entity with a release cadence.)

## ROR (#57) — the straightforward one

Exactly the `bioregistry` shape: single versioned bulk file → MERGE-upsert into `lake.ror.organization` on `ror_id`.

One difference the issue called out and it holds: **ROR dumps carry their own version**. The Zenodo *concept* record (6347574) always resolves to the newest release, whose `metadata.version` is the release tag — so the snapshot is tagged `v2.11`, the `scp`/`bugsigdb` treatment, not the pull date.

Verified against the real v2.11 dump (2026-08-03, 35.6 MB zip → 305 MB JSON), not assumed:

| check | result |
|---|---|
| rows | **135,710** |
| suggested key `ror_id` | **holds** — `id` unique across all 135,710, every one `https://ror.org/<lui>` |
| derived `name` | provably 1:1 — **every** record has exactly one `ror_display` name |
| idempotent re-run | no new snapshot, over nested `LIST<STRUCT>` columns |

Decisions worth reviewing:

- **JSON, not the CSV.** The dump ships both; ROR states JSON is authoritative and the CSV a flattened subset (it drops `relationships` — the parent/child org hierarchy — and per-name `lang`/`types`). It also sidesteps the free-text-quote trap: **804 organization names contain a bare `"`** (`Universitatea de Stat de Medicină și Farmacie "Nicolae Testemițanu"`). JSON quotes its own strings, so `quote=''`/`escape=''` never comes up.
- **Nested types land nested.** `names`, `locations`, `external_ids`, `relationships`, `links`, `admin` land as real `LIST<STRUCT>`, verified to round-trip DuckLake→Parquet and MERGE idempotently on all 135,710 rows. No JSON-as-VARCHAR fallback needed.
- **`ror_id` is the bare LUI** (`04ttjf776`), per #46's id-column convention. The URL is derivable and not landed; joining `lake.openalex.works_authorships` is `split_part(institution_ror, '/', -1) = ror_id` — the join key this lake already carries.
- **Country is deliberately not derived.** 131 records have >1 location (up to 5), so a `locations[1]` country would silently pick one. `locations` lands whole.
- **Trimming: honest about being defensive.** 288 names carry padding whitespace (216 acronyms, 71 aliases, 1 label) — but **zero** `ror_display` names do. The `trim()` on the derived `name` is kept as cheap insurance on the join column, not sold as a bug fix the way Reactome's genuinely was. The raw `names` list keeps padding verbatim, and a test asserts that.
- **Drift check adapted, not copied.** `auto_detect=false` with a stated type spec, but a JSON spec is *name*-addressed — drift can't shift values one column left the way it can in a headerless TSV; it fails quietly as an all-NULL column. `check_keys()` restores the loud failure by sweeping every record's top-level key set before loading. Costs 0.7 s on the real 305 MB file.

## ORCID (#56) — the scoping decision

**Decision: do not land the annual bulk Public Data File. Fetch the public API, scoped to a caller-supplied iD set.** The issue anticipated this trade-off; here are the real numbers behind taking it (figshare `10.23640/07243.30375589`, the 2025 file, checked 2026-08-11):

1. **Size.** The summaries archive alone is **46.33 GB compressed / 863,678 MB (~863 GB) uncompressed**, plus eleven activities archives of 16–19 GB each — ~237 GB compressed total.
2. **Shape — the real blocker.** It is **XML, one file per record**, unpacked into `summaries/<3-digit checksum>/<iD>.xml`. There is no scannable bulk artifact: DuckDB reads CSV/JSON/Parquet, not a tar of ~20M tiny XML documents. Landing it whole isn't "a big download", it's a bespoke XML shredder.
3. **No consumer.** **No table in this lake carries an ORCID iD today.** OpenAlex's authorship struct extracts `author.id`/`display_name` and the institution ROR, not `author.orcid`; RePORTER carries PI names and RePORTER-internal `pi_ids`. Landing 20M+ researcher records to join against zero rows is textbook speculative.

So the EL is demand-driven: `--orcids` (comma-separated list) or `--orcids-sql` (any query over the attached lake returning one column of iDs — #56's "iDs referenced by existing sources" path). It **refuses to run with neither**, rather than silently landing nothing — the "don't default silently" the issue asks for, enforced by a test.

The deviation and these numbers are in the module docstring, not implicit.

Endpoint choice: `expanded-search`, not `/record`. Both are unauthenticated on `pub.orcid.org`; `/record` is ~254 KB of activities per researcher, one round trip each, while `expanded-search` answers `orcid:(A OR B OR …)` for **100 iDs in a single ~0.4 s request** and returns exactly the crosswalk fields (iD, given/family/credit names, other names, emails, institution names). Verified on a real 100-iD batch: all 100 returned, `orcid-id` unique, no padded strings, no nulls in given/family names. An unknown or withdrawn iD simply doesn't come back — the response is a hit list, so absence is silent by design (documented).

The registry is live and rolling, so the snapshot is tagged by retrieval date (`retractionwatch` treatment). Fetched records are written to the raw layer as NDJSON before loading, so a re-curate needs no re-fetch.

Follow-up worth its own issue, not done here: adding `"orcid":"VARCHAR"` to OpenAlex's `_AUTHORSHIPS_STRUCT` is one line, but it carries a full re-ingest — once it lands, the ORCID default becomes a one-line `orcids_sql`.

## Licenses confirmed

- **ROR — CC0.** `ror.readme.io/docs/data-dump` (2026-08-11): *"All ROR IDs and metadata in the data dump are provided under the Creative Commons CC0 1.0 Universal Public Domain Dedication."* The Zenodo record independently carries `license: cc-zero`.
- **ORCID — CC0.** `info.orcid.org/annual-data-files` (2026-08-11): *"ORCID releases the Public Data File under a CC0 1.0 Public Domain Dedication as further described in our Privacy Policy."* The figshare record carries `license: CC0`. Same terms cover the public API's data. ORCID's Public Data File Use Policy adds community **norms** (cite ORCID, honor researcher deletions on refresh), not license conditions. Personal data: only fields a researcher chose to make public are returned — nothing here bypasses a record's privacy settings.

Both recorded in `docs/data-licenses.md` and in the `lake_ops.source` registry.

## Also in this PR

`download.get_json()` gains an optional `headers` kwarg — `pub.orcid.org` content-negotiates and serves **XML** to httpx's default `Accept: */*`. Two lines in the shared helper rather than a bespoke client in the ORCID module.

## Verification

- `uv run ruff check src/ tests/` — clean
- `uv run --all-extras pytest -q` — 117 passed, 13 skipped
- `python -m cdsci.lake.sources.{ror,orcid} run --help` — sane generated options, no hand-rolled typer app
- **Real bytes, both.** `RUN_INTEGRATION=1` ROR test pulls the full current dump and asserts `ror_id` uniqueness across all 135,710 rows (53 s); the ORCID one batch-fetches real public iDs from the live API. Both pass. Fixtures are real records sliced from the real dump/response.
- Local file-backed lake only — nothing was run against postgres/prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FposEN8ErZTLzsjTfSdZjj
