### PR TITLE
systemd: use %h/.local/bin/uv, not `env uv` (exit 127)

### DIFF
--- a/systemd/icite.service
+++ b/systemd/icite.service
@@ -13,7 +13,13 @@ Type=oneshot
 WorkingDirectory=/home/davsean/Documents/git/cdsci-lake
 EnvironmentFile=/home/davsean/Documents/git/cdsci-lake/.env
 Environment=CU_OPENALEX_LAKE_BACKEND=postgres
-ExecStart=/usr/bin/env uv run python -m cdsci.lake.sources.icite run
+# NOT `/usr/bin/env uv` -- systemd --user gives a minimal PATH
+# (/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin) that excludes ~/.local/bin,
+# where uv is installed, so `env uv` exits 127 "No such file or directory".
+# `systemd-analyze verify` does NOT catch it -- only actually starting the unit
+# does. This unit had the same defect but had not fired since 2026-08-10, so it
+# was latent rather than observed; next trigger was 2026-09-01.
+ExecStart=%h/.local/bin/uv run python -m cdsci.lake.sources.icite run
 # RuntimeMaxSec= silently has no effect on Type=oneshot (systemd quirk --
 # verified with `systemd-analyze verify`, don't reintroduce it). Use
 # TimeoutStartSec= instead, matching bioc-sync.service's precedent. A

--- a/systemd/retractionwatch.service
+++ b/systemd/retractionwatch.service
@@ -16,7 +16,12 @@ EnvironmentFile=/home/davsean/Documents/git/cdsci-lake/.env
 # omits this var so a plain test run can never hit prod by accident (see
 # cdsci.lake.config) -- set it explicitly here instead.
 Environment=CU_OPENALEX_LAKE_BACKEND=postgres
-ExecStart=/usr/bin/env uv run python -m cdsci.lake.sources.retractionwatch run
+# NOT `/usr/bin/env uv` -- systemd --user gives a minimal PATH
+# (/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin) that excludes ~/.local/bin,
+# where uv is installed, so `env uv` exits 127 "No such file or directory".
+# `systemd-analyze verify` does NOT catch it -- only actually starting the unit
+# does, which is how this shipped and failed every weekday until 2026-08-18.
+ExecStart=%h/.local/bin/uv run python -m cdsci.lake.sources.retractionwatch run
 # RuntimeMaxSec= silently has no effect on Type=oneshot (systemd quirk --
 # verified with `systemd-analyze verify`, don't reintroduce it). For
 # oneshot, the run-length ceiling is TimeoutStartSec=, matching


### PR DESCRIPTION
`retractionwatch.service` had failed on **every weekday trigger since deployment**, most recently 2026-08-17 07:00:

```
/usr/bin/env: 'uv': No such file or directory
retractionwatch.service: Main process exited, code=exited, status=127/n/a
```

`systemd --user` runs with a minimal `PATH` (`/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin`) that excludes `~/.local/bin`, where uv lives.

`icite.service` had the identical defect but had not fired since 2026-08-10, so it was latent rather than observed. Next trigger was 2026-09-01. Both fixed.

## Not a new answer — omicidx already solved this

Every unit in `omicidx/systemd/` uses `%h/.local/bin/uv` and carries a comment warning against `env uv`. This adopts that pattern and its comment rather than inventing a second one. Confirmed across all 8 uv-invoking user units: the 6 omicidx ones use `%h`, and only cdsci-lake's 2 used `env`.

## Why it survived review

`systemd-analyze verify` does **not** catch it — it passes clean. Only actually starting the unit does. The same class of trap as the `RuntimeMaxSec=` quirk already documented in these files.

## Verification

Ran the unit rather than just reloading it:

```
run:retractionwatch success -> lake.retractionwatch.retractions
(rows=71571, snapshot 2116->2117, run_id=734f3e95…)
Result=success  ExecMainStatus=0
```

It reported `changed`, so the missed runs had left real drift — this also picks up the load that should have happened this morning.

## Companion change

`monode/infrastructure/SCHEDULING.md` names this repo as the reference implementation and told readers to "copy those, not this doc's prose" — while its own worked example showed the broken `ExecStart`. That doc now carries the fixed line plus a row in the contract table, so the bug stops propagating to the next producer that follows it.